### PR TITLE
Remove futures_api feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ asynchronous software.
 ## Examples
 __UDP Echo Server__
 ```rust
-#![feature(async_await, await_macro, futures_api)]
+#![feature(async_await, await_macro)]
 
 use runtime::net::UdpSocket;
 

--- a/benches/baseline.rs
+++ b/benches/baseline.rs
@@ -1,4 +1,4 @@
-#![feature(test, async_await, await_macro, futures_api)]
+#![feature(test, async_await, await_macro)]
 
 extern crate test;
 

--- a/benches/native.rs
+++ b/benches/native.rs
@@ -1,4 +1,4 @@
-#![feature(test, async_await, await_macro, futures_api)]
+#![feature(test, async_await, await_macro)]
 #![warn(rust_2018_idioms)]
 
 extern crate test;

--- a/benches/tokio.rs
+++ b/benches/tokio.rs
@@ -1,4 +1,4 @@
-#![feature(test, async_await, await_macro, futures_api)]
+#![feature(test, async_await, await_macro)]
 #![warn(rust_2018_idioms)]
 
 extern crate test;

--- a/examples/guessing.rs
+++ b/examples/guessing.rs
@@ -7,7 +7,7 @@
 //! $ nc localhost 8080
 //! ```
 
-#![feature(async_await, await_macro, futures_api)]
+#![feature(async_await, await_macro)]
 
 use futures::prelude::*;
 use rand::Rng;

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, await_macro, futures_api)]
+#![feature(async_await, await_macro)]
 
 async fn say_hi() {
     println!("Hello world! 🤖");

--- a/examples/tcp-client.rs
+++ b/examples/tcp-client.rs
@@ -6,7 +6,7 @@
 //! $ cargo run --example tcp-echo
 //! ```
 
-#![feature(async_await, await_macro, futures_api)]
+#![feature(async_await, await_macro)]
 
 use futures::prelude::*;
 use runtime::net::TcpStream;

--- a/examples/tcp-echo.rs
+++ b/examples/tcp-echo.rs
@@ -3,7 +3,7 @@
 //! Run the server and connect to it with `nc 127.0.0.1 8080`.
 //! The server will wait for you to enter lines of text and then echo them back.
 
-#![feature(async_await, await_macro, futures_api)]
+#![feature(async_await, await_macro)]
 
 use futures::prelude::*;
 use runtime::net::TcpListener;

--- a/examples/tcp-proxy.rs
+++ b/examples/tcp-proxy.rs
@@ -1,6 +1,6 @@
 //! A TCP proxy server. Forwards connections from port 8081 to port 8080.
 
-#![feature(async_await, await_macro, futures_api)]
+#![feature(async_await, await_macro)]
 
 use futures::prelude::*;
 use futures::try_join;

--- a/examples/udp-client.rs
+++ b/examples/udp-client.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, await_macro, futures_api)]
+#![feature(async_await, await_macro)]
 
 //! UDP client.
 //!

--- a/examples/udp-echo.rs
+++ b/examples/udp-echo.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, await_macro, futures_api)]
+#![feature(async_await, await_macro)]
 
 //! UDP echo server.
 //!

--- a/runtime-attributes/src/lib.rs
+++ b/runtime-attributes/src/lib.rs
@@ -3,7 +3,7 @@
 
 #![forbid(unsafe_code, future_incompatible, rust_2018_idioms)]
 #![deny(missing_debug_implementations, nonstandard_style)]
-#![feature(async_await, await_macro, futures_api)]
+#![feature(async_await, await_macro)]
 #![recursion_limit = "512"]
 
 extern crate proc_macro;
@@ -17,7 +17,7 @@ use syn::spanned::Spanned;
 /// # Examples
 ///
 /// ```
-/// #![feature(async_await, futures_api)]
+/// #![feature(async_await)]
 ///
 /// #[runtime::main]
 /// async fn main() -> std::io::Result<()> {
@@ -65,7 +65,7 @@ pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// # Examples
 ///
 /// ```
-/// #![feature(async_await, futures_api)]
+/// #![feature(async_await)]
 ///
 /// #[runtime::test]
 /// async fn main() -> std::io::Result<()> {
@@ -107,7 +107,7 @@ pub fn test(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// # Examples
 ///
 /// ```
-/// #![feature(async_await, await_macro, futures_api, test)]
+/// #![feature(async_await, await_macro, test)]
 ///
 /// extern crate test;
 ///

--- a/runtime-native/src/lib.rs
+++ b/runtime-native/src/lib.rs
@@ -1,7 +1,7 @@
 //! A cross-platform asynchronous [Runtime](https://github.com/rustasync/runtime). See the [Runtime
 //! documentation](https://docs.rs/runtime) for more details.
 
-#![feature(async_await, await_macro, futures_api)]
+#![feature(async_await, await_macro)]
 #![deny(unsafe_code)]
 #![warn(
     missing_debug_implementations,

--- a/runtime-raw/src/lib.rs
+++ b/runtime-raw/src/lib.rs
@@ -5,7 +5,7 @@
 //! perform IO, then there's no need to bother with any of these types as they will have been
 //! implemented for you already.
 
-#![feature(futures_api, async_await, await_macro)]
+#![feature(async_await, await_macro)]
 #![deny(unsafe_code)]
 #![warn(
     missing_debug_implementations,

--- a/runtime-tokio/src/lib.rs
+++ b/runtime-tokio/src/lib.rs
@@ -2,7 +2,7 @@
 //! [Runtime](https://github.com/rustasync/runtime). See the [Runtime
 //! documentation](https://docs.rs/runtime) for more details.
 
-#![feature(async_await, await_macro, futures_api)]
+#![feature(async_await, await_macro)]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 //! ## Examples
 //! __UDP Echo Server__
 //! ```no_run
-//! #![feature(async_await, await_macro, futures_api)]
+//! #![feature(async_await, await_macro)]
 //!
 //! use runtime::net::UdpSocket;
 //!
@@ -85,7 +85,7 @@
 //! - [Runtime Tokio](https://docs.rs/runtime-tokio) provides a thread pool, bindings to the OS, and
 //!   a work-stealing scheduler.
 
-#![feature(futures_api, async_await, await_macro)]
+#![feature(async_await, await_macro)]
 #![deny(unsafe_code)]
 #![warn(
     missing_debug_implementations,

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -45,7 +45,7 @@ use futures::task::{Context, Poll};
 ///
 /// ## Examples
 /// ```no_run
-/// #![feature(async_await, await_macro, futures_api)]
+/// #![feature(async_await, await_macro)]
 ///
 /// use futures::prelude::*;
 /// use runtime::net::TcpStream;
@@ -84,7 +84,7 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```no_run
-    /// #![feature(async_await, await_macro, futures_api)]
+    /// #![feature(async_await, await_macro)]
     /// use runtime::net::TcpStream;
     ///
     /// # async fn connect_localhost() -> std::io::Result<()> {
@@ -104,7 +104,7 @@ impl TcpStream {
     ///
     /// ## Examples
     /// ```no_run
-    /// #![feature(async_await, await_macro, futures_api)]
+    /// #![feature(async_await, await_macro)]
     /// use runtime::net::TcpStream;
     /// use std::net::{IpAddr, Ipv4Addr};
     ///
@@ -124,7 +124,7 @@ impl TcpStream {
     ///
     /// ## Examples
     /// ```no_run
-    /// #![feature(async_await, await_macro, futures_api)]
+    /// #![feature(async_await, await_macro)]
     /// use runtime::net::TcpStream;
     /// use std::net::{IpAddr, Ipv4Addr};
     ///
@@ -150,7 +150,7 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```no_run
-    /// #![feature(async_await, await_macro, futures_api)]
+    /// #![feature(async_await, await_macro)]
     ///
     /// use std::net::Shutdown;
     /// use runtime::net::TcpStream;
@@ -291,7 +291,7 @@ impl fmt::Debug for Connect {
 ///
 /// # Examples
 /// ```ignore
-/// #![feature(async_await, await_macro, futures_api)]
+/// #![feature(async_await, await_macro)]
 ///
 /// use futures::prelude::*;
 /// use runtime::net::TcpListener;
@@ -367,7 +367,7 @@ impl TcpListener {
     /// # Examples
     ///
     /// ```no_run
-    /// #![feature(async_await, await_macro, futures_api)]
+    /// #![feature(async_await, await_macro)]
     ///
     /// use runtime::net::TcpListener;
     /// use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
@@ -397,7 +397,7 @@ impl TcpListener {
     /// ## Examples
     ///
     /// ```no_run
-    /// #![feature(async_await, await_macro, futures_api)]
+    /// #![feature(async_await, await_macro)]
     ///
     /// use futures::prelude::*;
     /// use runtime::net::TcpListener;
@@ -430,7 +430,7 @@ impl TcpListener {
     /// ## Examples
     ///
     /// ```no_run
-    /// #![feature(async_await, await_macro, futures_api)]
+    /// #![feature(async_await, await_macro)]
     ///
     /// use futures::prelude::*;
     /// use runtime::net::TcpListener;

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -36,7 +36,7 @@ use std::task::{Context, Poll};
 ///
 /// ## Examples
 /// ```no_run
-/// #![feature(async_await, await_macro, futures_api)]
+/// #![feature(async_await, await_macro)]
 ///
 /// use runtime::net::UdpSocket;
 ///
@@ -120,7 +120,7 @@ impl UdpSocket {
     /// # Examples
     ///
     /// ```no_run
-    /// #![feature(async_await, await_macro, futures_api)]
+    /// #![feature(async_await, await_macro)]
     /// # use std::error::Error;
     /// use runtime::net::UdpSocket;
     ///
@@ -163,7 +163,7 @@ impl UdpSocket {
     /// # Examples
     ///
     /// ```no_run
-    /// #![feature(async_await, await_macro, futures_api)]
+    /// #![feature(async_await, await_macro)]
     /// # use std::error::Error;
     /// use runtime::net::UdpSocket;
     ///
@@ -289,7 +289,7 @@ impl UdpSocket {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// #![feature(async_await, await_macro, futures_api)]
+    /// #![feature(async_await, await_macro)]
     ///
     /// use runtime::net::UdpSocket;
     /// use std::net::Ipv4Addr;
@@ -316,7 +316,7 @@ impl UdpSocket {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// #![feature(async_await, await_macro, futures_api)]
+    /// #![feature(async_await, await_macro)]
     ///
     /// use runtime::net::UdpSocket;
     /// use std::net::{Ipv6Addr, SocketAddr};

--- a/src/task.rs
+++ b/src/task.rs
@@ -13,7 +13,7 @@ use futures::task::{Context, Poll};
 /// # Examples
 ///
 /// ```
-/// #![feature(async_await, await_macro, futures_api)]
+/// #![feature(async_await, await_macro)]
 ///
 /// #[runtime::main]
 /// async fn main() {

--- a/tests/native.rs
+++ b/tests/native.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, await_macro, futures_api)]
+#![feature(async_await, await_macro)]
 
 use runtime_native::Native;
 

--- a/tests/tokio-current-thread.rs
+++ b/tests/tokio-current-thread.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, await_macro, futures_api)]
+#![feature(async_await, await_macro)]
 
 #[runtime::test(runtime_tokio::TokioCurrentThread)]
 async fn spawn() {

--- a/tests/tokio.rs
+++ b/tests/tokio.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, await_macro, futures_api)]
+#![feature(async_await, await_macro)]
 
 use runtime_tokio::Tokio;
 


### PR DESCRIPTION
This removes all occurrences of the futures_api feature flag.

## Motivation and Context
Since https://github.com/rust-lang/rust/pull/59739 has been merged it should no longer be necessary to specify the futures_api feature flag. The minimal nightly version required is `rustc 1.36.0-nightly (e305df184 2019-04-24)`.

Building the runtime crate using this nightly version otherwise shows:

```
warning: the feature `futures_api` has been stable since 1.36.0 and no longer requires an attribute to enable
```

FYI: Also see this pull request:
https://github.com/rust-lang-nursery/futures-rs/pull/1546/files

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

I think this in a way a breaking change as it changes the error behavior of rust stable and nightly versions that are older than nightly 2019-04-24.  Nevertheless since the features async_await and await_macro are not yet stabilized in stable < 1.36 the error that nightly rust is required should still be shown, just not specifically mentioning the futures_api feature. 