### PR TITLE
Update for futures v0.3.0-alpha.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["asynchronous", "network-programming", "filesystem", "concurrency"
 edition = "2018"
 
 [dependencies]
-futures-preview = { version = "0.3.0-alpha.14" }
+futures-preview = { version = "0.3.0-alpha.15" }
 runtime-attributes = { path = "runtime-attributes", version = "0.3.0-alpha.2" }
 runtime-raw = { path = "runtime-raw", version = "0.3.0-alpha.1" }
 runtime-native = { path = "runtime-native", version = "0.3.0-alpha.1" }
@@ -21,6 +21,7 @@ runtime-native = { path = "runtime-native", version = "0.3.0-alpha.1" }
 [dev-dependencies]
 failure = "0.1.5"
 futures01 = { package = "futures", version = "0.1" }
+futures-preview = { version = "0.3.0-alpha.15", features = ["nightly", "async-await"] }
 juliex = "0.3.0-alpha.2"
 mio = "0.6.16"
 rand = "0.6.5"

--- a/runtime-native/Cargo.toml
+++ b/runtime-native/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 
 [dependencies]
 async-datagram = "2.0.0"
-futures-preview = "0.3.0-alpha.13"
+futures-preview = "0.3.0-alpha.15"
 lazy_static = "1.0.0"
 romio = "0.3.0-alpha.5"
 runtime-raw = { path = "../runtime-raw", version = "0.3.0-alpha.1" }

--- a/runtime-raw/Cargo.toml
+++ b/runtime-raw/Cargo.toml
@@ -13,4 +13,4 @@ categories = ["asynchronous", "network-programming", "filesystem", "concurrency"
 edition = "2018"
 
 [dependencies]
-futures-preview = "0.3.0-alpha.13"
+futures-preview = "0.3.0-alpha.15"

--- a/runtime-tokio/Cargo.toml
+++ b/runtime-tokio/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["asynchronous", "network-programming", "filesystem", "concurrency"
 edition = "2018"
 
 [dependencies]
-futures-preview = { version = "0.3.0-alpha.13", features = ["compat", "io-compat"] }
+futures-preview = { version = "0.3.0-alpha.15", features = ["compat", "io-compat"] }
 futures01 = { package = "futures", version = "0.1" }
 lazy_static = "1.0.0"
 mio = "0.6.16"

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -21,6 +21,7 @@ use std::io;
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::pin::Pin;
 
+use futures::future::BoxFuture;
 use futures::io::*;
 use futures::prelude::*;
 use futures::ready;
@@ -219,9 +220,7 @@ impl AsyncWrite for TcpStream {
 pub struct Connect {
     addrs: Option<io::Result<VecDeque<SocketAddr>>>,
     last_err: Option<io::Error>,
-    future: Option<
-        Pin<Box<dyn Future<Output = io::Result<Pin<Box<dyn runtime_raw::TcpStream>>>> + Send>>,
-    >,
+    future: Option<BoxFuture<'static, io::Result<Pin<Box<dyn runtime_raw::TcpStream>>>>>,
     runtime: &'static dyn runtime_raw::Runtime,
 }
 

--- a/src/task.rs
+++ b/src/task.rs
@@ -2,7 +2,6 @@
 
 use std::pin::Pin;
 
-use futures::future::FutureObj;
 use futures::prelude::*;
 use futures::task::{Context, Poll};
 
@@ -37,7 +36,7 @@ where
     };
 
     runtime_raw::current_runtime()
-        .spawn_obj(FutureObj::from(Box::new(fut)))
+        .spawn_boxed(fut.boxed())
         .expect("cannot spawn a future");
 
     JoinHandle { rx }


### PR DESCRIPTION
Replace (most) usage of FutureObj with BoxFuture and use BoxFuture to
simplify some function signatures.

Enable the async-await feature for the tests.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #6.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

The only breaking change is changing `Runtime::spawn_obj` into `Runtime::spawn_boxed`, the other function signature changes are identical after type alias expansion.