### PR TITLE
Try for each concurrent

### DIFF
--- a/examples/guessing.rs
+++ b/examples/guessing.rs
@@ -63,7 +63,7 @@ async fn main() -> Result<(), failure::Error> {
 
     let incoming = listener.incoming().map_err(|e| e.into());
     incoming
-        .try_for_each_concurrent(!0, async move |stream| {
+        .try_for_each_concurrent(None, async move |stream| {
             runtime::spawn(play(stream)).await?;
             Ok::<(), failure::Error>(())
         })

--- a/examples/tcp-echo.rs
+++ b/examples/tcp-echo.rs
@@ -14,17 +14,14 @@ async fn main() -> std::io::Result<()> {
     println!("Listening on {}", listener.local_addr()?);
 
     // accept connections and process them in parallel
-    let mut incoming = listener.incoming();
-    while let Some(stream) = incoming.next().await {
+    listener.incoming().try_for_each_concurrent(!0, async move |stream| {
         runtime::spawn(async move {
-            let stream = stream?;
             println!("Accepting from: {}", stream.peer_addr()?);
 
             let (reader, writer) = &mut stream.split();
             reader.copy_into(writer).await?;
             Ok::<(), std::io::Error>(())
-        })
-        .await?;
-    }
+        }).await
+    }).await?;
     Ok(())
 }

--- a/examples/tcp-echo.rs
+++ b/examples/tcp-echo.rs
@@ -16,7 +16,7 @@ async fn main() -> std::io::Result<()> {
     // accept connections and process them in parallel
     listener
         .incoming()
-        .try_for_each_concurrent(!0, async move |stream| {
+        .try_for_each_concurrent(None, async move |stream| {
             runtime::spawn(async move {
                 println!("Accepting from: {}", stream.peer_addr()?);
 

--- a/examples/tcp-echo.rs
+++ b/examples/tcp-echo.rs
@@ -14,14 +14,18 @@ async fn main() -> std::io::Result<()> {
     println!("Listening on {}", listener.local_addr()?);
 
     // accept connections and process them in parallel
-    listener.incoming().try_for_each_concurrent(!0, async move |stream| {
-        runtime::spawn(async move {
-            println!("Accepting from: {}", stream.peer_addr()?);
+    listener
+        .incoming()
+        .try_for_each_concurrent(!0, async move |stream| {
+            runtime::spawn(async move {
+                println!("Accepting from: {}", stream.peer_addr()?);
 
-            let (reader, writer) = &mut stream.split();
-            reader.copy_into(writer).await?;
-            Ok::<(), std::io::Error>(())
-        }).await
-    }).await?;
+                let (reader, writer) = &mut stream.split();
+                reader.copy_into(writer).await?;
+                Ok::<(), std::io::Error>(())
+            })
+            .await
+        })
+        .await?;
     Ok(())
 }

--- a/examples/tcp-proxy.rs
+++ b/examples/tcp-proxy.rs
@@ -12,23 +12,27 @@ async fn main() -> std::io::Result<()> {
     println!("Listening on {}", listener.local_addr()?);
 
     // accept connections and process them in parallel
-    listener.incoming().try_for_each_concurrent(!0, async move |client| {
-        runtime::spawn(async move {
-            let server = TcpStream::connect("127.0.0.1:8080").await?;
-            println!(
-                "Proxying {} to {}",
-                client.peer_addr()?,
-                server.peer_addr()?
-            );
+    listener
+        .incoming()
+        .try_for_each_concurrent(!0, async move |client| {
+            runtime::spawn(async move {
+                let server = TcpStream::connect("127.0.0.1:8080").await?;
+                println!(
+                    "Proxying {} to {}",
+                    client.peer_addr()?,
+                    server.peer_addr()?
+                );
 
-            let (cr, cw) = &mut client.split();
-            let (sr, sw) = &mut server.split();
-            let a = cr.copy_into(sw);
-            let b = sr.copy_into(cw);
-            try_join!(a, b)?;
+                let (cr, cw) = &mut client.split();
+                let (sr, sw) = &mut server.split();
+                let a = cr.copy_into(sw);
+                let b = sr.copy_into(cw);
+                try_join!(a, b)?;
 
-            Ok::<(), std::io::Error>(())
-        }).await
-    }).await?;
+                Ok::<(), std::io::Error>(())
+            })
+            .await
+        })
+        .await?;
     Ok(())
 }

--- a/examples/tcp-proxy.rs
+++ b/examples/tcp-proxy.rs
@@ -11,11 +11,9 @@ async fn main() -> std::io::Result<()> {
     let mut listener = TcpListener::bind("127.0.0.1:8081")?;
     println!("Listening on {}", listener.local_addr()?);
 
-    // accept connections and process them serially
-    let mut incoming = listener.incoming();
-    while let Some(client) = incoming.next().await {
-        let handle = runtime::spawn(async move {
-            let client = client?;
+    // accept connections and process them in parallel
+    listener.incoming().try_for_each_concurrent(!0, async move |client| {
+        runtime::spawn(async move {
             let server = TcpStream::connect("127.0.0.1:8080").await?;
             println!(
                 "Proxying {} to {}",
@@ -30,9 +28,7 @@ async fn main() -> std::io::Result<()> {
             try_join!(a, b)?;
 
             Ok::<(), std::io::Error>(())
-        });
-
-        handle.await?;
-    }
+        }).await
+    }).await?;
     Ok(())
 }

--- a/examples/tcp-proxy.rs
+++ b/examples/tcp-proxy.rs
@@ -14,7 +14,7 @@ async fn main() -> std::io::Result<()> {
     // accept connections and process them in parallel
     listener
         .incoming()
-        .try_for_each_concurrent(!0, async move |client| {
+        .try_for_each_concurrent(None, async move |client| {
             runtime::spawn(async move {
                 let server = TcpStream::connect("127.0.0.1:8080").await?;
                 println!(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Process futures concurrently using `try_for_each_concurrent` as suggested by @withoutboats.

## Motivation and Context
This joins the results which means we can process futures in parallel rather than sequentially, but keep the same failure mode we had before.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
