### PR TITLE
for_await macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 futures-preview = "0.3.0-alpha.15"
 runtime-attributes = { path = "runtime-attributes", version = "0.3.0-alpha.3" }
 runtime-raw = { path = "runtime-raw", version = "0.3.0-alpha.2" }
-runtime-native = { path = "runtime-native", version = "0.3.0-alpha.2" }
+# runtime-native = { path = "runtime-native", version = "0.3.0-alpha.2" }
 
 [dev-dependencies]
 failure = "0.1.5"
@@ -40,3 +40,8 @@ members = [
   "runtime-raw",
   "runtime-tokio",
 ]
+
+[patch.crates-io.futures-preview]
+git = "https://github.com/taiki-e/futures-rs"
+branch = "async-stream"
+features = ["async-stream", "nightly"]

--- a/examples/tcp-echo.rs
+++ b/examples/tcp-echo.rs
@@ -14,14 +14,16 @@ async fn main() -> std::io::Result<()> {
     println!("Listening on {}", listener.local_addr()?);
 
     // accept connections and process them in parallel
-    await!(listener.incoming().try_for_each_concurrent(!0, async move |stream| {
-        await!(runtime::spawn(async move {
-            println!("Accepting from: {}", stream.peer_addr()?);
+    await!(listener
+        .incoming()
+        .try_for_each_concurrent(!0, async move |stream| {
+            await!(runtime::spawn(async move {
+                println!("Accepting from: {}", stream.peer_addr()?);
 
-            let (reader, writer) = &mut stream.split();
-            await!(reader.copy_into(writer))?;
-            Ok::<(), std::io::Error>(())
-        }))
-    }))?;
+                let (reader, writer) = &mut stream.split();
+                await!(reader.copy_into(writer))?;
+                Ok::<(), std::io::Error>(())
+            }))
+        }))?;
     Ok(())
 }

--- a/examples/tcp-echo.rs
+++ b/examples/tcp-echo.rs
@@ -14,7 +14,7 @@ async fn main() -> std::io::Result<()> {
     let mut listener = TcpListener::bind("127.0.0.1:8080")?;
     println!("Listening on {}", listener.local_addr()?);
 
-    #[for_await]
+    #[for_await(try_parallel)]
     for stream in listener.incoming() {
         println!("Accepting from: {}", stream.peer_addr()?);
 

--- a/examples/tcp-echo.rs
+++ b/examples/tcp-echo.rs
@@ -3,27 +3,22 @@
 //! Run the server and connect to it with `nc 127.0.0.1 8080`.
 //! The server will wait for you to enter lines of text and then echo them back.
 
-#![feature(async_await, await_macro)]
+#![feature(async_await, await_macro, stmt_expr_attributes, proc_macro_hygiene)]
 
 use futures::prelude::*;
 use runtime::net::TcpListener;
+use runtime::for_await;
 
-#[runtime::main]
+#[runtime::main(runtime_tokio::Tokio)]
 async fn main() -> std::io::Result<()> {
     let mut listener = TcpListener::bind("127.0.0.1:8080")?;
     println!("Listening on {}", listener.local_addr()?);
 
-    // accept connections and process them in parallel
-    await!(listener
-        .incoming()
-        .try_for_each_concurrent(!0, async move |stream| {
-            await!(runtime::spawn(async move {
-                println!("Accepting from: {}", stream.peer_addr()?);
+    #[for_await]
+    for stream in listener.incoming() {
+        println!("Accepting from: {}", stream.peer_addr()?);
 
-                let (reader, writer) = &mut stream.split();
-                await!(reader.copy_into(writer))?;
-                Ok::<(), std::io::Error>(())
-            }))
-        }))?;
-    Ok(())
+        let (reader, writer) = &mut stream.split();
+        await!(reader.copy_into(writer))?;
+    }
 }

--- a/examples/tcp-echo.rs
+++ b/examples/tcp-echo.rs
@@ -20,5 +20,7 @@ async fn main() -> std::io::Result<()> {
 
         let (reader, writer) = &mut stream.split();
         await!(reader.copy_into(writer))?;
+        Ok::<(), std::io::Error>(())
     }
+    Ok(())
 }

--- a/examples/tcp-proxy.rs
+++ b/examples/tcp-proxy.rs
@@ -11,11 +11,9 @@ async fn main() -> std::io::Result<()> {
     let mut listener = TcpListener::bind("127.0.0.1:8081")?;
     println!("Listening on {}", listener.local_addr()?);
 
-    // accept connections and process them serially
-    let mut incoming = listener.incoming();
-    while let Some(client) = await!(incoming.next()) {
-        let handle = runtime::spawn(async move {
-            let client = client?;
+    // accept connections and process them in parallel
+    await!(listener.incoming().try_for_each_concurrent(!0, async move |client| {
+        await!(runtime::spawn(async move {
             let server = await!(TcpStream::connect("127.0.0.1:8080"))?;
             println!(
                 "Proxying {} to {}",
@@ -30,9 +28,7 @@ async fn main() -> std::io::Result<()> {
             try_join!(a, b)?;
 
             Ok::<(), std::io::Error>(())
-        });
-
-        await!(handle)?;
-    }
+        }))
+    }))?;
     Ok(())
 }

--- a/runtime-attributes/Cargo.toml
+++ b/runtime-attributes/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-syn = { version = "0.15.33", features = ["full"] }
+syn = { version = "0.15.33", features = ["full", "extra-traits"] }
 proc-macro2 = { version = "0.4.29", features = ["nightly"] }
 quote = "0.6.12"
 

--- a/runtime-attributes/Cargo.toml
+++ b/runtime-attributes/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-syn = { version = "0.15.33", features = ["full", "extra-traits"] }
+syn = { version = "0.15.34", features = ["full", "extra-traits"] }
 proc-macro2 = { version = "0.4.29", features = ["nightly"] }
 quote = "0.6.12"
 

--- a/runtime-attributes/src/lib.rs
+++ b/runtime-attributes/src/lib.rs
@@ -223,7 +223,7 @@ pub fn for_await(attr: TokenStream, item: TokenStream) -> TokenStream {
             for #pat in #expr #body_block
         }
         .into(),
-        "parallel" => quote! {
+        "try_parallel" => quote! {
             let stream = #expr.map_err(|e| e.into());
             await!(stream.try_for_each_concurrent(None, async move |#expr| {
                 await!(runtime::spawn(async move #body_block))
@@ -231,7 +231,7 @@ pub fn for_await(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
         .into(),
         _ => TokenStream::from(quote_spanned! {
-            input.span() => compile_error!(r##"#[for_await] takes an optional argument of either "serial" or "parallel"##);
+            input.span() => compile_error!(r##"#[for_await] takes an optional argument of either "serial" or "try_parallel"##);
         }),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@ pub mod task;
 pub use task::spawn;
 
 #[doc(inline)]
-pub use runtime_attributes::{bench, test};
+pub use runtime_attributes::{bench, for_await, test};
 
 #[doc(inline)]
 #[cfg(not(test))] // NOTE: exporting main breaks tests, we should file an issue.
@@ -110,5 +110,5 @@ pub use runtime_attributes::main;
 #[doc(hidden)]
 pub use runtime_raw as raw;
 
-#[doc(hidden)]
-pub use runtime_native as native;
+// #[doc(hidden)]
+// pub use runtime_native as native;

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -175,14 +175,6 @@ impl AsyncRead for TcpStream {
     ) -> Poll<io::Result<usize>> {
         self.inner.as_mut().poll_read(cx, buf)
     }
-
-    fn poll_vectored_read(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        vec: &mut [&mut IoVec],
-    ) -> Poll<io::Result<usize>> {
-        self.inner.as_mut().poll_vectored_read(cx, vec)
-    }
 }
 
 impl AsyncWrite for TcpStream {
@@ -200,14 +192,6 @@ impl AsyncWrite for TcpStream {
 
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         self.inner.as_mut().poll_close(cx)
-    }
-
-    fn poll_vectored_write(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        vec: &[&IoVec],
-    ) -> Poll<io::Result<usize>> {
-        self.inner.as_mut().poll_vectored_write(cx, vec)
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds a `for_await` macro that can be used to parallelize spawning of items in a stream. Depends on https://github.com/rust-lang-nursery/futures-rs/pull/1548 to land first.

## Motivation and Context
This introduces a superset of the `futures::for_await` macro, where a concurrency mode can now be set in the attribute, which in turn can spawn individual tasks back on the executor.

This makes iterating over streams much more legible:
```rust
#[runtime::main]
async fn main() -> std::io::Result<()> {
    let mut listener = TcpListener::bind("127.0.0.1:8080")?;
    println!("Listening on {}", listener.local_addr()?);

    #[for_await(try_parallel)]
    for stream in listener.incoming() {
        println!("Accepting from: {}", stream.peer_addr()?);

        let (reader, writer) = &mut stream.split();
        await!(reader.copy_into(writer))?;
        Ok::<(), std::io::Error>(())
    }
    Ok(())
}
```

as compared to:
```rust
#[runtime::main]
async fn main() -> std::io::Result<()> {
    let mut listener = TcpListener::bind("127.0.0.1:8080")?;
    println!("Listening on {}", listener.local_addr()?);

    // accept connections and process them in parallel
    await!(listener
        .incoming()
        .try_for_each_concurrent(!0, async move |stream| {
            await!(runtime::spawn(async move {
                println!("Accepting from: {}", stream.peer_addr()?);

                let (reader, writer) = &mut stream.split();
                await!(reader.copy_into(writer))?;
                Ok::<(), std::io::Error>(())
            }))
        }))?;
    Ok(())
}
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
