### PR TITLE
[WIP] Update futures-preview to 0.3.0-alpha.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["asynchronous", "network-programming", "filesystem", "concurrency"
 edition = "2018"
 
 [dependencies]
-futures-preview = "0.3.0-alpha.15"
+futures-preview = "0.3.0-alpha.16"
 runtime-attributes = { path = "runtime-attributes", version = "0.3.0-alpha.3" }
 runtime-raw = { path = "runtime-raw", version = "0.3.0-alpha.2" }
 runtime-native = { path = "runtime-native", version = "0.3.0-alpha.2" }
@@ -21,7 +21,7 @@ runtime-native = { path = "runtime-native", version = "0.3.0-alpha.2" }
 [dev-dependencies]
 failure = "0.1.5"
 futures01 = { package = "futures", version = "0.1" }
-futures-preview = { version = "0.3.0-alpha.15", features = ["nightly", "async-await"] }
+futures-preview = { version = "0.3.0-alpha.16", features = ["nightly", "async-await"] }
 juliex = "0.3.0-alpha.5"
 mio = "0.6.16"
 rand = "0.6.5"
@@ -40,3 +40,7 @@ members = [
   "runtime-raw",
   "runtime-tokio",
 ]
+
+[patch.crates-io]
+romio = { git = "https://github.com/dbcfd/romio", branch = "futures-changes" }
+juliex = { git = "https://github.com/taiki-e/juliex", branch = "await" }

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ asynchronous software.
 ## Examples
 __UDP Echo Server__
 ```rust
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 use runtime::net::UdpSocket;
 
@@ -81,8 +81,8 @@ async fn main() -> std::io::Result<()> {
     println!("Listening on {}", socket.local_addr()?);
 
     loop {
-        let (recv, peer) = await!(socket.recv_from(&mut buf))?;
-        let sent = await!(socket.send_to(&buf[..recv], &peer))?;
+        let (recv, peer) = socket.recv_from(&mut buf).await?;
+        let sent = socket.send_to(&buf[..recv], &peer).await?;
         println!("Sent {} out of {} bytes to {}", sent, recv, peer);
     }
 }

--- a/benches/baseline.rs
+++ b/benches/baseline.rs
@@ -1,4 +1,4 @@
-#![feature(test, async_await, await_macro)]
+#![feature(test, async_await)]
 
 extern crate test;
 
@@ -43,13 +43,13 @@ mod baseline {
                 let tasks = (0..300)
                     .map(|_| {
                         spawn(async move {
-                            await!(Task { depth: 0 });
+                            Task { depth: 0 }.await;
                         })
                     })
                     .collect::<Vec<_>>();
 
                 for task in tasks {
-                    await!(task);
+                    task.await;
                 }
             })
         });
@@ -62,7 +62,7 @@ mod baseline {
                 let tasks = (0..25_000).map(|_| spawn(async {})).collect::<Vec<_>>();
 
                 for task in tasks {
-                    await!(task);
+                    task.await;
                 }
             })
         });
@@ -106,7 +106,7 @@ mod baseline {
                     .collect::<Vec<_>>();
 
                 for task in tasks {
-                    await!(task);
+                    task.await;
                 }
             })
         });
@@ -121,7 +121,7 @@ mod baseline {
         let (tx, rx) = futures::channel::oneshot::channel();
 
         let fut = async move {
-            let t = await!(fut);
+            let t = fut.await;
             let _ = tx.send(t);
         };
 

--- a/benches/common/mod.rs
+++ b/benches/common/mod.rs
@@ -31,13 +31,13 @@ macro_rules! benchmark_suite {
             let tasks = (0..300)
                 .map(|_| {
                     runtime::spawn(async {
-                        await!(Task { depth: 0 });
+                        Task { depth: 0 }.await;
                     })
                 })
                 .collect::<Vec<_>>();
 
             for task in tasks {
-                await!(task);
+                task.await;
             }
         }
 
@@ -48,7 +48,7 @@ macro_rules! benchmark_suite {
                 .collect::<Vec<_>>();
 
             for task in tasks {
-                await!(task);
+                task.await;
             }
         }
 
@@ -89,7 +89,7 @@ macro_rules! benchmark_suite {
                 .collect::<Vec<_>>();
 
             for task in tasks {
-                await!(task);
+                task.await;
             }
         }
     };

--- a/benches/native.rs
+++ b/benches/native.rs
@@ -1,4 +1,4 @@
-#![feature(test, async_await, await_macro)]
+#![feature(test, async_await)]
 #![warn(rust_2018_idioms)]
 
 extern crate test;

--- a/benches/tokio.rs
+++ b/benches/tokio.rs
@@ -1,4 +1,4 @@
-#![feature(test, async_await, await_macro)]
+#![feature(test, async_await)]
 #![warn(rust_2018_idioms)]
 
 extern crate test;

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 async fn say_hi() {
     println!("Hello world! 🤖");
@@ -6,5 +6,5 @@ async fn say_hi() {
 
 #[runtime::main]
 async fn main() {
-    await!(say_hi());
+    say_hi().await;
 }

--- a/examples/tcp-client.rs
+++ b/examples/tcp-client.rs
@@ -6,22 +6,22 @@
 //! $ cargo run --example tcp-echo
 //! ```
 
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 use futures::prelude::*;
 use runtime::net::TcpStream;
 
 #[runtime::main]
 async fn main() -> Result<(), failure::Error> {
-    let mut stream = await!(TcpStream::connect("127.0.0.1:8080"))?;
+    let mut stream = TcpStream::connect("127.0.0.1:8080").await?;
     println!("Connected to {}", &stream.peer_addr()?);
 
     let msg = "hello world";
     println!("<- {}", msg);
-    await!(stream.write_all(msg.as_bytes()))?;
+    stream.write_all(msg.as_bytes()).await?;
 
     let mut buf = vec![0u8; 1024];
-    await!(stream.read(&mut buf))?;
+    stream.read(&mut buf).await?;
     println!("-> {}\n", String::from_utf8(buf)?);
 
     Ok(())

--- a/examples/tcp-echo.rs
+++ b/examples/tcp-echo.rs
@@ -3,7 +3,7 @@
 //! Run the server and connect to it with `nc 127.0.0.1 8080`.
 //! The server will wait for you to enter lines of text and then echo them back.
 
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 use futures::prelude::*;
 use runtime::net::TcpListener;
@@ -15,13 +15,13 @@ async fn main() -> std::io::Result<()> {
 
     // accept connections and process them in parallel
     let mut incoming = listener.incoming();
-    while let Some(stream) = await!(incoming.next()) {
+    while let Some(stream) = incoming.next().await {
         runtime::spawn(async move {
             let stream = stream?;
             println!("Accepting from: {}", stream.peer_addr()?);
 
             let (reader, writer) = &mut stream.split();
-            await!(reader.copy_into(writer))?;
+            reader.copy_into(writer).await?;
             Ok::<(), std::io::Error>(())
         });
     }

--- a/examples/tcp-proxy.rs
+++ b/examples/tcp-proxy.rs
@@ -1,7 +1,6 @@
 //! A TCP proxy server. Forwards connections from port 8081 to port 8080.
 
 #![feature(async_await)]
-#![feature(await_macro)] // TODO: When the next version of futures-preview released, remove this.
 
 use futures::prelude::*;
 use futures::try_join;

--- a/examples/tcp-proxy.rs
+++ b/examples/tcp-proxy.rs
@@ -1,6 +1,7 @@
 //! A TCP proxy server. Forwards connections from port 8081 to port 8080.
 
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
+#![feature(await_macro)] // TODO: When the next version of futures-preview released, remove this.
 
 use futures::prelude::*;
 use futures::try_join;
@@ -13,10 +14,10 @@ async fn main() -> std::io::Result<()> {
 
     // accept connections and process them serially
     let mut incoming = listener.incoming();
-    while let Some(client) = await!(incoming.next()) {
+    while let Some(client) = incoming.next().await {
         let handle = runtime::spawn(async move {
             let client = client?;
-            let server = await!(TcpStream::connect("127.0.0.1:8080"))?;
+            let server = TcpStream::connect("127.0.0.1:8080").await?;
             println!(
                 "Proxying {} to {}",
                 client.peer_addr()?,
@@ -32,7 +33,7 @@ async fn main() -> std::io::Result<()> {
             Ok::<(), std::io::Error>(())
         });
 
-        await!(handle)?;
+        handle.await?;
     }
     Ok(())
 }

--- a/examples/udp-client.rs
+++ b/examples/udp-client.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 //! UDP client.
 //!
@@ -16,10 +16,10 @@ async fn main() -> std::io::Result<()> {
 
     let msg = "hello world";
     println!("<- {}", msg);
-    await!(socket.send_to(msg.as_bytes(), "127.0.0.1:8080"))?;
+    socket.send_to(msg.as_bytes(), "127.0.0.1:8080").await?;
 
     let mut buf = vec![0u8; 1024];
-    await!(socket.recv_from(&mut buf))?;
+    socket.recv_from(&mut buf).await?;
     println!("-> {}\n", String::from_utf8_lossy(&mut buf));
 
     Ok(())

--- a/examples/udp-echo.rs
+++ b/examples/udp-echo.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 //! UDP echo server.
 //!
@@ -17,8 +17,8 @@ async fn main() -> std::io::Result<()> {
     println!("Listening on {}", socket.local_addr()?);
 
     loop {
-        let (recv, peer) = await!(socket.recv_from(&mut buf))?;
-        let sent = await!(socket.send_to(&buf[..recv], &peer))?;
+        let (recv, peer) = socket.recv_from(&mut buf).await?;
+        let sent = socket.send_to(&buf[..recv], &peer).await?;
         println!("Sent {} out of {} bytes to {}", sent, recv, peer);
     }
 }

--- a/runtime-attributes/src/lib.rs
+++ b/runtime-attributes/src/lib.rs
@@ -3,7 +3,7 @@
 
 #![forbid(unsafe_code, future_incompatible, rust_2018_idioms)]
 #![deny(missing_debug_implementations, nonstandard_style)]
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 #![recursion_limit = "512"]
 
 extern crate proc_macro;
@@ -62,7 +62,7 @@ pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
             }
 
             runtime::raw::enter(#rt, async {
-                await!(main())
+                main().await
             })
         }
 
@@ -120,13 +120,13 @@ pub fn test(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// # Examples
 ///
 /// ```ignore
-/// #![feature(async_await, await_macro, test)]
+/// #![feature(async_await, test)]
 ///
 /// extern crate test;
 ///
 /// #[runtime::test]
 /// async fn spawn_and_await() {
-///   await!(runtime::spawn(async {}));
+///   runtime::spawn(async {}).await;
 /// }
 /// ```
 #[proc_macro_attribute]

--- a/runtime-native/Cargo.toml
+++ b/runtime-native/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["asynchronous", "network-programming", "filesystem", "concurrency"
 edition = "2018"
 
 [dependencies]
-futures-preview = { version = "0.3.0-alpha.15", features = ["compat"] }
+futures-preview = { version = "0.3.0-alpha.16", features = ["compat"] }
 runtime-raw = { path = "../runtime-raw", version = "0.3.0-alpha.2" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/runtime-native/src/lib.rs
+++ b/runtime-native/src/lib.rs
@@ -1,7 +1,7 @@
 //! A cross-platform asynchronous [Runtime](https://github.com/rustasync/runtime). See the [Runtime
 //! documentation](https://docs.rs/runtime) for more details.
 
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 #![deny(unsafe_code)]
 #![warn(
     missing_debug_implementations,

--- a/runtime-raw/Cargo.toml
+++ b/runtime-raw/Cargo.toml
@@ -13,4 +13,4 @@ categories = ["asynchronous", "network-programming", "filesystem", "concurrency"
 edition = "2018"
 
 [dependencies]
-futures-preview = "0.3.0-alpha.15"
+futures-preview = "0.3.0-alpha.16"

--- a/runtime-raw/src/lib.rs
+++ b/runtime-raw/src/lib.rs
@@ -5,7 +5,7 @@
 //! perform IO, then there's no need to bother with any of these types as they will have been
 //! implemented for you already.
 
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 #![deny(unsafe_code)]
 #![warn(
     missing_debug_implementations,
@@ -61,7 +61,7 @@ where
     let (tx, rx) = futures::channel::oneshot::channel();
 
     let fut = async move {
-        let t = await!(fut);
+        let t = fut.await;
         let _ = tx.send(t);
     };
 

--- a/runtime-tokio/Cargo.toml
+++ b/runtime-tokio/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["asynchronous", "network-programming", "filesystem", "concurrency"
 edition = "2018"
 
 [dependencies]
-futures-preview = { version = "0.3.0-alpha.15", features = ["compat", "io-compat"] }
+futures-preview = { version = "0.3.0-alpha.16", features = ["compat", "io-compat"] }
 futures01 = { package = "futures", version = "0.1" }
 lazy_static = "1.3.0"
 mio = "0.6.16"

--- a/runtime-tokio/src/lib.rs
+++ b/runtime-tokio/src/lib.rs
@@ -2,7 +2,7 @@
 //! [Runtime](https://github.com/rustasync/runtime). See the [Runtime
 //! documentation](https://docs.rs/runtime) for more details.
 
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 //! ## Examples
 //! __UDP Echo Server__
 //! ```no_run
-//! #![feature(async_await, await_macro)]
+//! #![feature(async_await)]
 //!
 //! use runtime::net::UdpSocket;
 //!
@@ -28,8 +28,8 @@
 //!     println!("Listening on {}", socket.local_addr()?);
 //!
 //!     loop {
-//!         let (recv, peer) = await!(socket.recv_from(&mut buf))?;
-//!         let sent = await!(socket.send_to(&buf[..recv], &peer))?;
+//!         let (recv, peer) = socket.recv_from(&mut buf).await?;
+//!         let sent = socket.send_to(&buf[..recv], &peer).await?;
 //!         println!("Sent {} out of {} bytes to {}", sent, recv, peer);
 //!     }
 //! }
@@ -85,7 +85,7 @@
 //! - [Runtime Tokio](https://docs.rs/runtime-tokio) provides a thread pool, bindings to the OS, and
 //!   a work-stealing scheduler.
 
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 #![deny(unsafe_code)]
 #![warn(
     missing_debug_implementations,

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -46,22 +46,22 @@ use futures::task::{Context, Poll};
 ///
 /// ## Examples
 /// ```no_run
-/// #![feature(async_await, await_macro)]
+/// #![feature(async_await)]
 ///
 /// use futures::prelude::*;
 /// use runtime::net::TcpStream;
 ///
 /// #[runtime::main]
 /// async fn main() -> Result<(), failure::Error> {
-///     let mut stream = await!(TcpStream::connect("127.0.0.1:8080"))?;
+///     let mut stream = TcpStream::connect("127.0.0.1:8080").await?;
 ///     println!("Connected to {}", &stream.peer_addr()?);
 ///
 ///     let msg = "hello world";
 ///     println!("<- {}", msg);
-///     await!(stream.write_all(msg.as_bytes()))?;
+///     stream.write_all(msg.as_bytes()).await?;
 ///
 ///     let mut buf = vec![0u8; 1024];
-///     await!(stream.read(&mut buf))?;
+///     stream.read(&mut buf).await?;
 ///     println!("-> {}\n", std::str::from_utf8(&mut buf)?);
 ///
 ///     Ok(())
@@ -85,11 +85,11 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```no_run
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// use runtime::net::TcpStream;
     ///
     /// # async fn connect_localhost() -> std::io::Result<()> {
-    /// let stream = await!(TcpStream::connect("127.0.0.1:0"))?;
+    /// let stream = TcpStream::connect("127.0.0.1:0").await?;
     /// # Ok(())}
     /// ```
     pub fn connect<A: ToSocketAddrs>(addr: A) -> Connect {
@@ -105,13 +105,13 @@ impl TcpStream {
     ///
     /// ## Examples
     /// ```no_run
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// use runtime::net::TcpStream;
     /// use std::net::{IpAddr, Ipv4Addr};
     ///
     /// # #[runtime::main]
     /// # async fn main() -> std::io::Result<()> {
-    /// let stream = await!(TcpStream::connect("127.0.0.1:8080"))?;
+    /// let stream = TcpStream::connect("127.0.0.1:8080").await?;
     ///
     /// let expected = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
     /// assert_eq!(stream.local_addr()?.ip(), expected);
@@ -125,12 +125,12 @@ impl TcpStream {
     ///
     /// ## Examples
     /// ```no_run
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// use runtime::net::TcpStream;
     /// use std::net::{IpAddr, Ipv4Addr};
     ///
     /// # async fn connect_localhost() -> std::io::Result<()> {
-    /// let stream = await!(TcpStream::connect("127.0.0.1:8080"))?;
+    /// let stream = TcpStream::connect("127.0.0.1:8080").await?;
     ///
     /// let expected = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
     /// assert_eq!(stream.peer_addr()?.ip(), expected);
@@ -151,14 +151,14 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```no_run
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     ///
     /// use std::net::Shutdown;
     /// use runtime::net::TcpStream;
     ///
     /// # #[runtime::main]
     /// # async fn main() -> std::io::Result<()> {
-    /// let stream = await!(TcpStream::connect("127.0.0.1:8080"))?;
+    /// let stream = TcpStream::connect("127.0.0.1:8080").await?;
     /// stream.shutdown(Shutdown::Both)?;
     /// # Ok(()) }
     /// ```
@@ -290,7 +290,7 @@ impl fmt::Debug for Connect {
 ///
 /// # Examples
 /// ```ignore
-/// #![feature(async_await, await_macro)]
+/// #![feature(async_await)]
 ///
 /// use futures::prelude::*;
 /// use runtime::net::TcpListener;
@@ -302,13 +302,13 @@ impl fmt::Debug for Connect {
 ///
 ///     // accept connections and process them in parallel
 ///     let mut incoming = listener.incoming();
-///     while let Some(stream) = await!(incoming.next()) {
+///     while let Some(stream) = incoming.next().await {
 ///         runtime::spawn(async move {
 ///             let stream = stream?;
 ///             println!("Accepting from: {}", stream.peer_addr()?);
 ///
 ///             let (reader, writer) = &mut stream.split();
-///             await!(reader.copy_into(writer))?;
+///             reader.copy_into(writer).await?;
 ///             Ok::<(), std::io::Error>(())
 ///         });
 ///     }
@@ -366,7 +366,7 @@ impl TcpListener {
     /// # Examples
     ///
     /// ```no_run
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     ///
     /// use runtime::net::TcpListener;
     /// use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
@@ -396,7 +396,7 @@ impl TcpListener {
     /// ## Examples
     ///
     /// ```no_run
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     ///
     /// use futures::prelude::*;
     /// use runtime::net::TcpListener;
@@ -404,7 +404,7 @@ impl TcpListener {
     /// # async fn work () -> Result<(), Box<dyn std::error::Error + 'static>> {
     /// let mut listener = TcpListener::bind("127.0.0.1:0")?;
     /// let mut incoming = listener.incoming();
-    /// while let Some(stream) = await!(incoming.next()) {
+    /// while let Some(stream) = incoming.next().await {
     ///     match stream {
     ///         Ok(stream) => println!("new client!"),
     ///         Err(e) => { /* connection failed */ }
@@ -429,14 +429,14 @@ impl TcpListener {
     /// ## Examples
     ///
     /// ```no_run
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     ///
     /// use futures::prelude::*;
     /// use runtime::net::TcpListener;
     ///
     /// # async fn work () -> Result<(), Box<dyn std::error::Error + 'static>> {
     /// let mut listener = TcpListener::bind("127.0.0.1:0")?;
-    /// let (stream, addr) = await!(listener.accept())?;
+    /// let (stream, addr) = listener.accept().await?;
     /// println!("Connected to {}", addr);
     /// # Ok(())}
     /// ```

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -176,12 +176,12 @@ impl AsyncRead for TcpStream {
         self.inner.as_mut().poll_read(cx, buf)
     }
 
-    fn poll_vectored_read(
+    fn poll_read_vectored(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-        vec: &mut [&mut IoVec],
+        bufs: &mut [IoSliceMut<'_>],
     ) -> Poll<io::Result<usize>> {
-        self.inner.as_mut().poll_vectored_read(cx, vec)
+        self.inner.as_mut().poll_read_vectored(cx, bufs)
     }
 }
 
@@ -202,12 +202,12 @@ impl AsyncWrite for TcpStream {
         self.inner.as_mut().poll_close(cx)
     }
 
-    fn poll_vectored_write(
+    fn poll_write_vectored(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-        vec: &[&IoVec],
+        bufs: &[IoSlice<'_>],
     ) -> Poll<io::Result<usize>> {
-        self.inner.as_mut().poll_vectored_write(cx, vec)
+        self.inner.as_mut().poll_write_vectored(cx, bufs)
     }
 }
 

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -36,7 +36,7 @@ use std::task::{Context, Poll};
 ///
 /// ## Examples
 /// ```no_run
-/// #![feature(async_await, await_macro)]
+/// #![feature(async_await)]
 ///
 /// use runtime::net::UdpSocket;
 ///
@@ -48,8 +48,8 @@ use std::task::{Context, Poll};
 ///     println!("Listening on {}", socket.local_addr()?);
 ///
 ///     loop {
-///         let (recv, peer) = await!(socket.recv_from(&mut buf))?;
-///         let sent = await!(socket.send_to(&buf[..recv], &peer))?;
+///         let (recv, peer) = socket.recv_from(&mut buf).await?;
+///         let sent = socket.send_to(&buf[..recv], &peer).await?;
 ///         println!("Sent {} out of {} bytes to {}", sent, recv, peer);
 ///     }
 /// }
@@ -120,7 +120,7 @@ impl UdpSocket {
     /// # Examples
     ///
     /// ```no_run
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # use std::error::Error;
     /// use runtime::net::UdpSocket;
     ///
@@ -135,7 +135,7 @@ impl UdpSocket {
     /// let mut socket = UdpSocket::bind("127.0.0.1:0")?;
     ///
     /// let addr = "127.0.0.1:7878";
-    /// let sent = await!(socket.send_to(THE_MERCHANT_OF_VENICE, &addr))?;
+    /// let sent = socket.send_to(THE_MERCHANT_OF_VENICE, &addr).await?;
     /// println!("Sent {} bytes to {}", sent, addr);
     /// # Ok(())
     /// # }
@@ -163,7 +163,7 @@ impl UdpSocket {
     /// # Examples
     ///
     /// ```no_run
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # use std::error::Error;
     /// use runtime::net::UdpSocket;
     ///
@@ -171,7 +171,7 @@ impl UdpSocket {
     /// let mut socket = UdpSocket::bind("127.0.0.1:0")?;
     ///
     /// let mut buf = vec![0; 1024];
-    /// let (recv, peer) = await!(socket.recv_from(&mut buf))?;
+    /// let (recv, peer) = socket.recv_from(&mut buf).await?;
     /// println!("Received {} bytes from {}", recv, peer);
     /// # Ok(buf)
     /// # }
@@ -289,7 +289,7 @@ impl UdpSocket {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     ///
     /// use runtime::net::UdpSocket;
     /// use std::net::Ipv4Addr;
@@ -316,7 +316,7 @@ impl UdpSocket {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     ///
     /// use runtime::net::UdpSocket;
     /// use std::net::{Ipv6Addr, SocketAddr};

--- a/src/task.rs
+++ b/src/task.rs
@@ -12,7 +12,7 @@ use futures::task::{Context, Poll};
 /// # Examples
 ///
 /// ```
-/// #![feature(async_await, await_macro)]
+/// #![feature(async_await)]
 ///
 /// #[runtime::main]
 /// async fn main() {
@@ -20,7 +20,7 @@ use futures::task::{Context, Poll};
 ///         println!("running the future");
 ///         42
 ///     });
-///     assert_eq!(await!(handle), 42);
+///     assert_eq!(handle.await, 42);
 /// }
 /// ```
 pub fn spawn<F, T>(fut: F) -> JoinHandle<T>
@@ -31,7 +31,7 @@ where
     let (tx, rx) = futures::channel::oneshot::channel();
 
     let fut = async move {
-        let t = await!(fut);
+        let t = fut.await;
         let _ = tx.send(t);
     };
 

--- a/tests/native.rs
+++ b/tests/native.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 use runtime_native::Native;
 
@@ -8,5 +8,5 @@ async fn spawn() {
         println!("hello planet from Native");
         42
     });
-    assert_eq!(await!(handle), 42);
+    assert_eq!(handle.await, 42);
 }

--- a/tests/tokio-current-thread.rs
+++ b/tests/tokio-current-thread.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 #[runtime::test(runtime_tokio::TokioCurrentThread)]
 async fn spawn() {
@@ -6,5 +6,5 @@ async fn spawn() {
         println!("hello planet from Tokio current-thread");
         42
     });
-    assert_eq!(await!(handle), 42);
+    assert_eq!(handle.await, 42);
 }

--- a/tests/tokio.rs
+++ b/tests/tokio.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 use runtime_tokio::Tokio;
 
@@ -8,5 +8,5 @@ async fn spawn() {
         println!("hello planet from Tokio");
         42
     });
-    assert_eq!(await!(handle), 42);
+    assert_eq!(handle.await, 42);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

`await` syntax was implemented in https://github.com/rust-lang/rust/pull/60586, and nightly-2019-05-09 has been released with the changes. Also, `await!` macro will be removed in the future.

Then, futures 0.3.0-alpha.16 was released.

Refs: [migration tool](https://github.com/taiki-e/replace-await)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

With this change, the minimum required version will go up to nightly-2019-05-09.