### PR TITLE
Wasm main

### DIFF
--- a/runtime-attributes/src/lib.rs
+++ b/runtime-attributes/src/lib.rs
@@ -1,6 +1,10 @@
 //! Proc Macro attributes for the [Runtime](https://github.com/rustasync/runtime) crate. See the
 //! [Runtime](https://docs.rs/runtime) documentation for more details.
 
+// This file is currently a bit messy because proc macros are not allowed to be split into multiple
+// files. This means that the code for all targets needs to live in this one file. We don't love
+// it, but it beats the alternatives.
+
 #![forbid(unsafe_code, future_incompatible, rust_2018_idioms)]
 #![deny(missing_debug_implementations, nonstandard_style)]
 #![feature(async_await)]
@@ -25,6 +29,7 @@ use syn::spanned::Spanned;
 /// }
 /// ```
 #[cfg(not(test))] // NOTE: exporting main breaks tests, we should file an issue.
+#[cfg(not(all(feature = "wasm-bindgen", target_arch = "wasm32")))]
 #[proc_macro_attribute]
 pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
     let rt = if attr.is_empty() {
@@ -83,6 +88,7 @@ pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///     Ok(())
 /// }
 /// ```
+#[cfg(not(all(feature = "wasm-bindgen", target_arch = "wasm32")))]
 #[proc_macro_attribute]
 pub fn test(attr: TokenStream, item: TokenStream) -> TokenStream {
     let rt = if attr.is_empty() {
@@ -129,6 +135,7 @@ pub fn test(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///   runtime::spawn(async {}).await;
 /// }
 /// ```
+#[cfg(not(all(feature = "wasm-bindgen", target_arch = "wasm32")))]
 #[proc_macro_attribute]
 pub fn bench(attr: TokenStream, item: TokenStream) -> TokenStream {
     let rt = if attr.is_empty() {
@@ -168,4 +175,64 @@ pub fn bench(attr: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     result.into()
+}
+
+////////////////////////////////////
+// target = "wasm32-unknown-unknown"
+////////////////////////////////////
+
+#[cfg(not(test))] // NOTE: exporting main breaks tests, we should file an issue.
+#[cfg(all(feature = "wasm-bindgen", target_arch = "wasm32"))]
+#[proc_macro_attribute]
+pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(item as syn::ItemFn);
+    let rt = if attr.is_empty() {
+        syn::parse_str("runtime::native::Native").unwrap()
+    } else {
+        syn::parse_macro_input!(attr as syn::Expr)
+    };
+
+    let ret = &input.decl.output;
+    let inputs = &input.decl.inputs;
+    let name = &input.ident;
+    let body = &input.block;
+    let attrs = &input.attrs;
+
+    if name != "main" {
+        return TokenStream::from(quote_spanned! {
+          compile_error!("only the main function can be tagged with #[runtime::main]");
+        });
+    }
+
+    if input.asyncness.is_none() {
+        return TokenStream::from(quote_spanned! {
+            input.span() => compile_error!("the async keyword is missing from the function declaration");
+        });
+    }
+
+    quote!{
+        #[wasm_bindgen(start)]
+        pub fn main() #ret {
+            #(#attrs)*
+            async fn main(#(#inputs),*) #ret {
+                #body
+            }
+
+            runtime::raw::enter(#rt, async {
+                await!(main())
+            })
+        }
+    }
+}
+
+#[cfg(all(feature = "wasm-bindgen", target_arch = "wasm32"))]
+#[proc_macro_attribute]
+pub fn test(attr: TokenStream, item: TokenStream) -> TokenStream {
+    panic!("Async tests are currently not supported in wasm");
+}
+
+#[cfg(all(feature = "wasm-bindgen", target_arch = "wasm32"))]
+#[proc_macro_attribute]
+pub fn bench(attr: TokenStream, item: TokenStream) -> TokenStream {
+    panic!("Async benchmarks are currently not supported in wasm");
 }

--- a/runtime-native/src/lib.rs
+++ b/runtime-native/src/lib.rs
@@ -15,7 +15,7 @@ mod wasm32;
 #[cfg(all(feature = "wasm-bindgen", target_arch = "wasm32"))]
 pub use wasm32::Native;
 
-#[cfg(not(all(feature = "wasm-bindgen", target_arch = "wasm32")))]
+#[cfg(not(target_arch = "wasm32"))]
 mod not_wasm32;
-#[cfg(not(all(feature = "wasm-bindgen", target_arch = "wasm32")))]
+#[cfg(not(target_arch = "wasm32"))]
 pub use not_wasm32::Native;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Allows `#[runtime::main]` to work for `wasm-32-unknown-unknown`.

## Motivation and Context
This is fun because it allows you to write `async fn main` in wasm, and it'll work as expected. This sets up `#[wasm_bindgen(start)]` for you also, which makes it very convenient. This means that we could rewrite [wasm-pretend-main](https://github.com/yoshuawuyts/wasm-pretend-main/blob/master/src/main.rs) from:
```rust

use wasm_bindgen::prelude::*;

#[global_allocator]
static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;

#[wasm_bindgen(start)]
pub fn main() {
    #[cfg(not(debug_assertions))]
    console_error_panic_hook::set_once();

    println!("Hello, wasm-pretend-main!");
}
```

into
```rust
use wasm_bindgen::prelude::*;

#[global_allocator]
static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;

#[runtime::main]
async fn main() {
    #[cfg(not(debug_assertions))]
    console_error_panic_hook::set_once();

    println!("Hello, wasm-pretend-main!");
}
```

---
This is useful because it removes the need to setup the async browser loop, but more importantly: it allows us to write the same code for client + server, which brings us closer to something that feels like "isomorphic Rust".

A step after this would be to tackle the boilerplate around error handling + setting up the allocator. Perhaps `wasm-pack` might provide a convenient avenue, but the exact details need to be fleshed out. In any case, this should save us quite a bit of setup all together.

cc/ @fitzgen @rylev

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
