### PR TITLE
Native as optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,15 @@ keywords = ["async", "runtime", "generic", "tokio", "romio"]
 categories = ["asynchronous", "network-programming", "filesystem", "concurrency", "api-bindings"]
 edition = "2018"
 
+[features]
+default = ["native"]
+native = ["runtime-native"]
+
 [dependencies]
 futures-preview = "0.3.0-alpha.16"
 runtime-attributes = { path = "runtime-attributes", version = "0.3.0-alpha.4" }
 runtime-raw = { path = "runtime-raw", version = "0.3.0-alpha.3" }
-runtime-native = { path = "runtime-native", version = "0.3.0-alpha.3" }
+runtime-native = { path = "runtime-native", version = "0.3.0-alpha.3", optional = true }
 
 [dev-dependencies]
 failure = "0.1.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,4 +111,5 @@ pub use runtime_attributes::main;
 pub use runtime_raw as raw;
 
 #[doc(hidden)]
+#[cfg(feature = "native")]
 pub use runtime_native as native;


### PR DESCRIPTION
## Description

I made `runtime-native` optional, and `native` feature to enable `runtime-native` crate. I also made `native` feature as default feature so normal user can use the native runtime easily.

And I wanted to make `cargo test --no-default-features` pass, so I added `require-features` as `native` for all tests that require the native runtime.

Since `runtime` manipulate the `main` function, doc tests will not pass in following code (from `task.rs`):
```rust
/// ```
/// #![feature(async_await)]
///
/// # #[cfg(feature = "native")]
/// #[runtime::main]
/// async fn main() {
///     let handle = runtime::spawn(async {
///         println!("running the future");
///         42
///     });
///     assert_eq!(handle.await, 42);
/// }
/// ```
```
I think it's because they cannot find the `main` function.

So I added a 'fallback' `main` function for not `native` cfg:
```rust
/// ```
/// #![feature(async_await)]
///
/// # #[cfg(not(feature = "native"))]
/// # fn main() { }
/// # #[cfg(feature = "native")]
/// #[runtime::main]
/// async fn main() {
///     let handle = runtime::spawn(async {
///         println!("running the future");
///         42
///     });
///     assert_eq!(handle.await, 42);
/// }
/// ```
```
So I could make `cargo test --no-default-features` pass.

## Motivation and Context

Since `runtime` is pluggable with various backend, it will be great if the native runtime, `runtime-native` crate, is optional. If I use `runtime-tokio` as backend, I don't want any other runtime backend in my dependency tree.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
