### PR TITLE
Fix blocking in guessing example.

### DIFF
--- a/examples/guessing.rs
+++ b/examples/guessing.rs
@@ -63,7 +63,7 @@ async fn main() -> Result<(), failure::Error> {
 
     let mut incoming = listener.incoming();
     while let Some(stream) = incoming.next().await {
-        runtime::spawn(play(stream?)).await?;
+        runtime::spawn(play(stream?));
     }
     Ok(())
 }


### PR DESCRIPTION
## Description
Remove `await?` inner the while loop which block the server from serving the next client.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
