### PR TITLE
Time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ futures-preview = "0.3.0-alpha.16"
 runtime-attributes = { path = "runtime-attributes", version = "0.3.0-alpha.4" }
 runtime-raw = { path = "runtime-raw", version = "0.3.0-alpha.3" }
 runtime-native = { path = "runtime-native", version = "0.3.0-alpha.3", optional = true }
+pin-utils = "0.1.0-alpha.4"
 
 [dev-dependencies]
 failure = "0.1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ juliex = "0.3.0-alpha.6"
 mio = "0.6.16"
 rand = "0.6.5"
 runtime-tokio = { path = "runtime-tokio", version = "0.3.0-alpha.3" }
+futures-timer = "0.1.1"
 tokio = "0.1.19"
 
 [profile.bench]
@@ -44,3 +45,6 @@ members = [
   "runtime-raw",
   "runtime-tokio",
 ]
+
+[patch.crates-io]
+futures-timer = { path = "../../alexcrichton/futures-timer" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ juliex = "0.3.0-alpha.6"
 mio = "0.6.16"
 rand = "0.6.5"
 runtime-tokio = { path = "runtime-tokio", version = "0.3.0-alpha.3" }
-futures-timer = "0.1.1"
 tokio = "0.1.19"
 
 [profile.bench]
@@ -45,6 +44,3 @@ members = [
   "runtime-raw",
   "runtime-tokio",
 ]
-
-[patch.crates-io]
-futures-timer = { path = "../../alexcrichton/futures-timer" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ futures-preview = "0.3.0-alpha.16"
 runtime-attributes = { path = "runtime-attributes", version = "0.3.0-alpha.4" }
 runtime-raw = { path = "runtime-raw", version = "0.3.0-alpha.3" }
 runtime-native = { path = "runtime-native", version = "0.3.0-alpha.3", optional = true }
-pin-utils = "0.1.0-alpha.4"
 
 [dev-dependencies]
 failure = "0.1.5"

--- a/ci/install-rust.yml
+++ b/ci/install-rust.yml
@@ -2,7 +2,10 @@ steps:
   # Linux and macOS.
   - script: |
       set -e
-      curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUSTUP_TOOLCHAIN
+      curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain none
+      export PATH=$PATH:$HOME/.cargo/bin
+      rustup toolchain install $RUSTUP_TOOLCHAIN
+      rustup default $RUSTUP_TOOLCHAIN
       echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"
     env:
       RUSTUP_TOOLCHAIN: ${{parameters.rust_version}}

--- a/runtime-native/Cargo.toml
+++ b/runtime-native/Cargo.toml
@@ -21,7 +21,7 @@ async-datagram = "2.2.0"
 juliex = "0.3.0-alpha.6"
 lazy_static = "1.3.0"
 romio = "0.3.0-alpha.7"
-futures-timer = "0.2.0"
+futures-timer = "0.2.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 futures01 = { package = "futures", version = "0.1" }

--- a/runtime-native/Cargo.toml
+++ b/runtime-native/Cargo.toml
@@ -21,7 +21,7 @@ async-datagram = "2.2.0"
 juliex = "0.3.0-alpha.6"
 lazy_static = "1.3.0"
 romio = "0.3.0-alpha.7"
-futures-timer = "0.1.1"
+futures-timer = "0.2.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 futures01 = { package = "futures", version = "0.1" }

--- a/runtime-native/Cargo.toml
+++ b/runtime-native/Cargo.toml
@@ -21,6 +21,7 @@ async-datagram = "2.2.0"
 juliex = "0.3.0-alpha.6"
 lazy_static = "1.3.0"
 romio = "0.3.0-alpha.7"
+futures-timer = "0.1.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 futures01 = { package = "futures", version = "0.1" }

--- a/runtime-native/src/not_wasm32.rs
+++ b/runtime-native/src/not_wasm32.rs
@@ -1,6 +1,7 @@
 use futures::prelude::*;
 use futures::{future::BoxFuture, task::SpawnError};
 use lazy_static::lazy_static;
+use futures_timer::Delay as AsyncDelay;
 
 use std::io;
 use std::net::SocketAddr;
@@ -9,9 +10,11 @@ use std::time::Duration;
 
 mod tcp;
 mod udp;
+mod time;
 
 use tcp::{TcpListener, TcpStream};
 use udp::UdpSocket;
+use time::Delay;
 
 lazy_static! {
     static ref JULIEX_THREADPOOL: juliex::ThreadPool = {
@@ -60,8 +63,9 @@ impl runtime_raw::Runtime for Native {
         Ok(Box::pin(UdpSocket { romio_socket }))
     }
 
-    fn new_delay(&self, _dur: Duration) -> Pin<Box<dyn runtime_raw::Delay>> {
-        unimplemented!();
+    fn new_delay(&self, dur: Duration) -> Pin<Box<dyn runtime_raw::Delay>> {
+        let async_delay = AsyncDelay::new(dur);
+        Box::pin(Delay { async_delay })
     }
 
     fn new_delay_at(&self, _dur: Duration) -> Pin<Box<dyn runtime_raw::Delay>> {

--- a/runtime-native/src/not_wasm32.rs
+++ b/runtime-native/src/not_wasm32.rs
@@ -1,7 +1,7 @@
 use futures::prelude::*;
 use futures::{future::BoxFuture, task::SpawnError};
+use futures_timer::{Delay as AsyncDelay, Interval as AsyncInterval};
 use lazy_static::lazy_static;
-use futures_timer::Delay as AsyncDelay;
 
 use std::io;
 use std::net::SocketAddr;
@@ -9,12 +9,12 @@ use std::pin::Pin;
 use std::time::{Duration, Instant};
 
 mod tcp;
-mod udp;
 mod time;
+mod udp;
 
 use tcp::{TcpListener, TcpStream};
+use time::{Delay, Interval};
 use udp::UdpSocket;
-use time::Delay;
 
 lazy_static! {
     static ref JULIEX_THREADPOOL: juliex::ThreadPool = {
@@ -73,7 +73,8 @@ impl runtime_raw::Runtime for Native {
         Box::pin(Delay { async_delay })
     }
 
-    fn new_interval(&self, _dur: Duration) -> Pin<Box<dyn runtime_raw::Interval>> {
-        unimplemented!();
+    fn new_interval(&self, dur: Duration) -> Pin<Box<dyn runtime_raw::Interval>> {
+        let async_interval = AsyncInterval::new(dur);
+        Box::pin(Interval { async_interval })
     }
 }

--- a/runtime-native/src/not_wasm32.rs
+++ b/runtime-native/src/not_wasm32.rs
@@ -6,7 +6,7 @@ use futures_timer::Delay as AsyncDelay;
 use std::io;
 use std::net::SocketAddr;
 use std::pin::Pin;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 mod tcp;
 mod udp;
@@ -68,8 +68,9 @@ impl runtime_raw::Runtime for Native {
         Box::pin(Delay { async_delay })
     }
 
-    fn new_delay_at(&self, _dur: Duration) -> Pin<Box<dyn runtime_raw::Delay>> {
-        unimplemented!();
+    fn new_delay_at(&self, at: Instant) -> Pin<Box<dyn runtime_raw::Delay>> {
+        let async_delay = AsyncDelay::new_at(at);
+        Box::pin(Delay { async_delay })
     }
 
     fn new_interval(&self, _dur: Duration) -> Pin<Box<dyn runtime_raw::Interval>> {

--- a/runtime-native/src/not_wasm32.rs
+++ b/runtime-native/src/not_wasm32.rs
@@ -5,6 +5,7 @@ use lazy_static::lazy_static;
 use std::io;
 use std::net::SocketAddr;
 use std::pin::Pin;
+use std::time::Duration;
 
 mod tcp;
 mod udp;
@@ -57,5 +58,17 @@ impl runtime_raw::Runtime for Native {
     ) -> io::Result<Pin<Box<dyn runtime_raw::UdpSocket>>> {
         let romio_socket = romio::UdpSocket::bind(&addr)?;
         Ok(Box::pin(UdpSocket { romio_socket }))
+    }
+
+    fn new_delay(&self, _dur: Duration) -> Pin<Box<dyn runtime_raw::Delay>> {
+        unimplemented!();
+    }
+
+    fn new_delay_at(&self, _dur: Duration) -> Pin<Box<dyn runtime_raw::Delay>> {
+        unimplemented!();
+    }
+
+    fn new_interval(&self, _dur: Duration) -> Pin<Box<dyn runtime_raw::Interval>> {
+        unimplemented!();
     }
 }

--- a/runtime-native/src/not_wasm32/time.rs
+++ b/runtime-native/src/not_wasm32/time.rs
@@ -1,0 +1,23 @@
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Instant;
+
+use futures::prelude::*;
+use futures_timer::Delay as AsyncDelay;
+
+pub(crate) struct Delay {
+    pub(crate) async_delay: AsyncDelay,
+}
+
+impl runtime_raw::Delay for Delay {}
+
+impl Future for Delay {
+    type Output = Instant;
+
+    #[inline]
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // TODO: this should probably not be fallible.
+        futures::ready!(Pin::new(&mut self.async_delay).poll(cx)).unwrap();
+        Poll::Ready(Instant::now())
+    }
+}

--- a/runtime-native/src/not_wasm32/time.rs
+++ b/runtime-native/src/not_wasm32/time.rs
@@ -1,9 +1,10 @@
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::Instant;
+use std::fmt;
 
 use futures::prelude::*;
-use futures_timer::Delay as AsyncDelay;
+use futures_timer::{Delay as AsyncDelay, Interval as AsyncInterval};
 
 pub(crate) struct Delay {
     pub(crate) async_delay: AsyncDelay,
@@ -19,5 +20,36 @@ impl Future for Delay {
         // TODO: this should probably not be fallible.
         futures::ready!(Pin::new(&mut self.async_delay).poll(cx)).unwrap();
         Poll::Ready(Instant::now())
+    }
+}
+
+// TODO: implement this
+impl fmt::Debug for Delay {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        unimplemented!();
+    }
+}
+
+pub(crate) struct Interval {
+    pub(crate) async_interval: AsyncInterval,
+}
+
+impl runtime_raw::Interval for Interval {}
+
+impl Stream for Interval {
+    type Item = Instant;
+
+    #[inline]
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // TODO: this should probably not be fallible.
+        futures::ready!(Pin::new(&mut self.async_interval).poll_next(cx)).unwrap();
+        Poll::Ready(Some(Instant::now()))
+    }
+}
+
+// TODO: implement this
+impl fmt::Debug for Interval {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        unimplemented!();
     }
 }

--- a/runtime-native/src/not_wasm32/time.rs
+++ b/runtime-native/src/not_wasm32/time.rs
@@ -1,7 +1,7 @@
+use std::fmt;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::Instant;
-use std::fmt;
 
 use futures::prelude::*;
 use futures_timer::{Delay as AsyncDelay, Interval as AsyncInterval};

--- a/runtime-native/src/not_wasm32/time.rs
+++ b/runtime-native/src/not_wasm32/time.rs
@@ -1,4 +1,3 @@
-use std::fmt;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::Instant;
@@ -6,6 +5,7 @@ use std::time::Instant;
 use futures::prelude::*;
 use futures_timer::{Delay as AsyncDelay, Interval as AsyncInterval};
 
+#[derive(Debug)]
 pub(crate) struct Delay {
     pub(crate) async_delay: AsyncDelay,
 }
@@ -22,16 +22,7 @@ impl Future for Delay {
     }
 }
 
-// TODO: implement this
-impl fmt::Debug for Delay {
-    // fmt::Display::fmt(self.async_delay, f)
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        f.debug_struct("Delay")
-            .field("when", &"...")
-            .finish()
-    }
-}
-
+#[derive(Debug)]
 pub(crate) struct Interval {
     pub(crate) async_interval: AsyncInterval,
 }
@@ -45,16 +36,5 @@ impl Stream for Interval {
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         futures::ready!(Pin::new(&mut self.async_interval).poll_next(cx)).unwrap();
         Poll::Ready(Some(Instant::now()))
-    }
-}
-
-// TODO: implement this
-impl fmt::Debug for Interval {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        // fmt::Display::fmt(self.async_interval, f)
-        f.debug_struct("Interval")
-            .field("delay", &"...")
-            .field("interval", &"...")
-            .finish()
     }
 }

--- a/runtime-native/src/not_wasm32/time.rs
+++ b/runtime-native/src/not_wasm32/time.rs
@@ -17,7 +17,6 @@ impl Future for Delay {
 
     #[inline]
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        // TODO: this should probably not be fallible.
         futures::ready!(Pin::new(&mut self.async_delay).poll(cx)).unwrap();
         Poll::Ready(Instant::now())
     }
@@ -25,8 +24,11 @@ impl Future for Delay {
 
 // TODO: implement this
 impl fmt::Debug for Delay {
-    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        unimplemented!();
+    // fmt::Display::fmt(self.async_delay, f)
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        f.debug_struct("Delay")
+            .field("when", &"...")
+            .finish()
     }
 }
 
@@ -41,7 +43,6 @@ impl Stream for Interval {
 
     #[inline]
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        // TODO: this should probably not be fallible.
         futures::ready!(Pin::new(&mut self.async_interval).poll_next(cx)).unwrap();
         Poll::Ready(Some(Instant::now()))
     }
@@ -49,7 +50,11 @@ impl Stream for Interval {
 
 // TODO: implement this
 impl fmt::Debug for Interval {
-    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        unimplemented!();
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        // fmt::Display::fmt(self.async_interval, f)
+        f.debug_struct("Interval")
+            .field("delay", &"...")
+            .field("interval", &"...")
+            .finish()
     }
 }

--- a/runtime-native/src/wasm32.rs
+++ b/runtime-native/src/wasm32.rs
@@ -5,6 +5,7 @@ use futures::{future::BoxFuture, task::SpawnError};
 use std::io;
 use std::net::SocketAddr;
 use std::pin::Pin;
+use std::time::Duration;
 
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::future_to_promise;
@@ -40,5 +41,17 @@ impl runtime_raw::Runtime for Native {
         _addr: &SocketAddr,
     ) -> io::Result<Pin<Box<dyn runtime_raw::UdpSocket>>> {
         panic!("Binding UDP sockets is currently not supported in wasm");
+    }
+
+    fn new_delay(&self, _dur: Duration) -> Pin<Box<dyn runtime_raw::Delay>> {
+        unimplemented!();
+    }
+
+    fn new_delay_at(&self, _dur: Duration) -> Pin<Box<dyn runtime_raw::Delay>> {
+        unimplemented!();
+    }
+
+    fn new_interval(&self, _dur: Duration) -> Pin<Box<dyn runtime_raw::Interval>> {
+        unimplemented!();
     }
 }

--- a/runtime-native/src/wasm32.rs
+++ b/runtime-native/src/wasm32.rs
@@ -5,7 +5,7 @@ use futures::{future::BoxFuture, task::SpawnError};
 use std::io;
 use std::net::SocketAddr;
 use std::pin::Pin;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::future_to_promise;
@@ -47,7 +47,7 @@ impl runtime_raw::Runtime for Native {
         unimplemented!();
     }
 
-    fn new_delay_at(&self, _dur: Duration) -> Pin<Box<dyn runtime_raw::Delay>> {
+    fn new_delay_at(&self, _at: Instant) -> Pin<Box<dyn runtime_raw::Delay>> {
         unimplemented!();
     }
 

--- a/runtime-native/src/wasm32.rs
+++ b/runtime-native/src/wasm32.rs
@@ -44,14 +44,14 @@ impl runtime_raw::Runtime for Native {
     }
 
     fn new_delay(&self, _dur: Duration) -> Pin<Box<dyn runtime_raw::Delay>> {
-        unimplemented!();
+        panic!("Timers are currently not supported in wasm");
     }
 
     fn new_delay_at(&self, _at: Instant) -> Pin<Box<dyn runtime_raw::Delay>> {
-        unimplemented!();
+        panic!("Timers are currently not supported in wasm");
     }
 
     fn new_interval(&self, _dur: Duration) -> Pin<Box<dyn runtime_raw::Interval>> {
-        unimplemented!();
+        panic!("Timers are currently not supported in wasm");
     }
 }

--- a/runtime-raw/src/lib.rs
+++ b/runtime-raw/src/lib.rs
@@ -99,13 +99,13 @@ pub trait Runtime: Send + Sync + 'static {
     /// `UdpSocket` would prevent it from being a trait object.
     fn bind_udp_socket(&self, addr: &SocketAddr) -> io::Result<Pin<Box<dyn UdpSocket>>>;
 
-    /// Create a new Future that sleeps for the given duration.
+    /// Create a new Future that wakes up after the given duration
     ///
     /// This method is defined on the `Runtime` trait because defining it on
     /// `Delay` would prevent it from being a trait object.
     fn new_delay(&self, dur: Duration) -> Pin<Box<dyn Delay>>;
 
-    /// Create a new Future that sleeps until the given time.
+    /// Create a new Future that wakes up at the given time.
     ///
     /// This method is defined on the `Runtime` trait because defining it on
     /// `Delay` would prevent it from being a trait object.

--- a/runtime-raw/src/lib.rs
+++ b/runtime-raw/src/lib.rs
@@ -19,19 +19,22 @@ use futures::future::BoxFuture;
 use futures::prelude::*;
 use futures::task::SpawnError;
 
+use std::time::Duration;
 use std::cell::Cell;
 use std::io;
 use std::net::SocketAddr;
 use std::pin::Pin;
 
-mod tcp;
 mod udp;
+mod tcp;
+mod time;
 
-pub use tcp::*;
 pub use udp::*;
+pub use tcp::*;
+pub use time::*;
 
 thread_local! {
-  static RUNTIME: Cell<Option<&'static dyn Runtime>> = Cell::new(None);
+    static RUNTIME: Cell<Option<&'static dyn Runtime>> = Cell::new(None);
 }
 
 /// Get the current runtime.
@@ -95,4 +98,22 @@ pub trait Runtime: Send + Sync + 'static {
     /// This method is defined on the `Runtime` trait because defining it on
     /// `UdpSocket` would prevent it from being a trait object.
     fn bind_udp_socket(&self, addr: &SocketAddr) -> io::Result<Pin<Box<dyn UdpSocket>>>;
+
+    /// Create a new Future that sleeps for the given duration.
+    ///
+    /// This method is defined on the `Runtime` trait because defining it on
+    /// `Delay` would prevent it from being a trait object.
+    fn new_delay(&self, dur: Duration) -> Pin<Box<dyn Delay>>;
+
+    /// Create a new Future that sleeps until the given time.
+    ///
+    /// This method is defined on the `Runtime` trait because defining it on
+    /// `Delay` would prevent it from being a trait object.
+    fn new_delay_at(&self, dur: Duration) -> Pin<Box<dyn Delay>>;
+
+    /// A stream representing notifications at a fixed interval.
+    ///
+    /// This method is defined on the `Runtime` trait because defining it on
+    /// `Interval` would prevent it from being a trait object.
+    fn new_interval(&self, dur: Duration) -> Pin<Box<dyn Interval>>;
 }

--- a/runtime-raw/src/lib.rs
+++ b/runtime-raw/src/lib.rs
@@ -19,19 +19,19 @@ use futures::future::BoxFuture;
 use futures::prelude::*;
 use futures::task::SpawnError;
 
-use std::time::{Duration, Instant};
 use std::cell::Cell;
 use std::io;
 use std::net::SocketAddr;
 use std::pin::Pin;
+use std::time::{Duration, Instant};
 
-mod udp;
 mod tcp;
 mod time;
+mod udp;
 
-pub use udp::*;
 pub use tcp::*;
 pub use time::*;
+pub use udp::*;
 
 thread_local! {
     static RUNTIME: Cell<Option<&'static dyn Runtime>> = Cell::new(None);

--- a/runtime-raw/src/lib.rs
+++ b/runtime-raw/src/lib.rs
@@ -19,7 +19,7 @@ use futures::future::BoxFuture;
 use futures::prelude::*;
 use futures::task::SpawnError;
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use std::cell::Cell;
 use std::io;
 use std::net::SocketAddr;
@@ -109,7 +109,7 @@ pub trait Runtime: Send + Sync + 'static {
     ///
     /// This method is defined on the `Runtime` trait because defining it on
     /// `Delay` would prevent it from being a trait object.
-    fn new_delay_at(&self, dur: Duration) -> Pin<Box<dyn Delay>>;
+    fn new_delay_at(&self, at: Instant) -> Pin<Box<dyn Delay>>;
 
     /// A stream representing notifications at a fixed interval.
     ///

--- a/runtime-raw/src/time.rs
+++ b/runtime-raw/src/time.rs
@@ -5,7 +5,7 @@ use std::future::Future;
 use futures::Stream;
 
 /// A future representing the notification that an elapsed duration has occurred.
-pub trait Delay: Future<Output = Instant> + Debug + Send {}
+pub trait Delay: Future<Output = Instant> + Send {}
 
 /// A stream representing notifications at a fixed interval.
 pub trait Interval: Stream<Item = Instant> + Debug + Send {}

--- a/runtime-raw/src/time.rs
+++ b/runtime-raw/src/time.rs
@@ -1,0 +1,11 @@
+use std::fmt::Debug;
+use std::time::{Duration, Instant};
+use std::future::Future;
+
+use futures::Stream;
+
+/// A future representing the notification that an elapsed duration has occurred.
+pub trait Delay: Future<Output = Instant> + Debug + Send {}
+
+/// A stream representing notifications at a fixed interval.
+pub trait Interval: Stream<Item = Instant> + Debug + Send {}

--- a/runtime-raw/src/time.rs
+++ b/runtime-raw/src/time.rs
@@ -5,7 +5,7 @@ use std::future::Future;
 use futures::Stream;
 
 /// A future representing the notification that an elapsed duration has occurred.
-pub trait Delay: Future<Output = Instant> + Send {}
+pub trait Delay: Future<Output = Instant> + Debug + Send {}
 
 /// A stream representing notifications at a fixed interval.
 pub trait Interval: Stream<Item = Instant> + Debug + Send {}

--- a/runtime-raw/src/time.rs
+++ b/runtime-raw/src/time.rs
@@ -1,5 +1,5 @@
 use std::fmt::Debug;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 use std::future::Future;
 
 use futures::Stream;

--- a/runtime-raw/src/time.rs
+++ b/runtime-raw/src/time.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
-use std::time::Instant;
 use std::future::Future;
+use std::time::Instant;
 
 use futures::Stream;
 

--- a/runtime-tokio/src/lib.rs
+++ b/runtime-tokio/src/lib.rs
@@ -81,15 +81,15 @@ impl runtime_raw::Runtime for Tokio {
     }
 
     fn new_delay(&self, _dur: Duration) -> Pin<Box<dyn runtime_raw::Delay>> {
-        unimplemented!();
+        panic!("Timers are currently not supported in runtime-tokio");
     }
 
     fn new_delay_at(&self, _at: Instant) -> Pin<Box<dyn runtime_raw::Delay>> {
-        unimplemented!();
+        panic!("Timers are currently not supported in runtime-tokio");
     }
 
     fn new_interval(&self, _dur: Duration) -> Pin<Box<dyn runtime_raw::Interval>> {
-        unimplemented!();
+        panic!("Timers are currently not supported in runtime-tokio");
     }
 }
 
@@ -158,14 +158,14 @@ impl runtime_raw::Runtime for TokioCurrentThread {
     }
 
     fn new_delay(&self, _dur: Duration) -> Pin<Box<dyn runtime_raw::Delay>> {
-        unimplemented!();
+        panic!("Timers are currently not supported in runtime-tokio");
     }
 
     fn new_delay_at(&self, _at: Instant) -> Pin<Box<dyn runtime_raw::Delay>> {
-        unimplemented!();
+        panic!("Timers are currently not supported in runtime-tokio");
     }
 
     fn new_interval(&self, _dur: Duration) -> Pin<Box<dyn runtime_raw::Interval>> {
-        unimplemented!();
+        panic!("Timers are currently not supported in runtime-tokio");
     }
 }

--- a/runtime-tokio/src/lib.rs
+++ b/runtime-tokio/src/lib.rs
@@ -26,12 +26,12 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 mod tcp;
-mod udp;
 mod time;
+mod udp;
 
 use tcp::{TcpListener, TcpStream};
-use udp::UdpSocket;
 use time::{Delay, Interval};
+use udp::UdpSocket;
 
 /// The default Tokio runtime.
 #[derive(Debug)]

--- a/runtime-tokio/src/lib.rs
+++ b/runtime-tokio/src/lib.rs
@@ -22,7 +22,7 @@ use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::{mpsc, Mutex};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 mod tcp;
 mod udp;
@@ -84,7 +84,7 @@ impl runtime_raw::Runtime for Tokio {
         unimplemented!();
     }
 
-    fn new_delay_at(&self, _dur: Duration) -> Pin<Box<dyn runtime_raw::Delay>> {
+    fn new_delay_at(&self, _at: Instant) -> Pin<Box<dyn runtime_raw::Delay>> {
         unimplemented!();
     }
 
@@ -161,7 +161,7 @@ impl runtime_raw::Runtime for TokioCurrentThread {
         unimplemented!();
     }
 
-    fn new_delay_at(&self, _dur: Duration) -> Pin<Box<dyn runtime_raw::Delay>> {
+    fn new_delay_at(&self, _at: Instant) -> Pin<Box<dyn runtime_raw::Delay>> {
         unimplemented!();
     }
 

--- a/runtime-tokio/src/lib.rs
+++ b/runtime-tokio/src/lib.rs
@@ -83,16 +83,19 @@ impl runtime_raw::Runtime for Tokio {
         Ok(Box::pin(UdpSocket { tokio_socket }))
     }
 
-    fn new_delay(&self, _dur: Duration) -> Pin<Box<dyn runtime_raw::Delay>> {
-        panic!("Timers are currently not supported in runtime-tokio");
+    fn new_delay(&self, dur: Duration) -> Pin<Box<dyn runtime_raw::Delay>> {
+        let tokio_delay = TokioDelay::new(Instant::now() + dur);
+        Box::pin(Delay { tokio_delay })
     }
 
-    fn new_delay_at(&self, _at: Instant) -> Pin<Box<dyn runtime_raw::Delay>> {
-        panic!("Timers are currently not supported in runtime-tokio");
+    fn new_delay_at(&self, at: Instant) -> Pin<Box<dyn runtime_raw::Delay>> {
+        let tokio_delay = TokioDelay::new(at);
+        Box::pin(Delay { tokio_delay })
     }
 
-    fn new_interval(&self, _dur: Duration) -> Pin<Box<dyn runtime_raw::Interval>> {
-        panic!("Timers are currently not supported in runtime-tokio");
+    fn new_interval(&self, dur: Duration) -> Pin<Box<dyn runtime_raw::Interval>> {
+        let tokio_interval = TokioInterval::new(Instant::now(), dur);
+        Box::pin(Interval { tokio_interval })
     }
 }
 

--- a/runtime-tokio/src/lib.rs
+++ b/runtime-tokio/src/lib.rs
@@ -22,6 +22,7 @@ use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::{mpsc, Mutex};
 use std::thread;
+use std::time::Duration;
 
 mod tcp;
 mod udp;
@@ -77,6 +78,18 @@ impl runtime_raw::Runtime for Tokio {
     ) -> io::Result<Pin<Box<dyn runtime_raw::UdpSocket>>> {
         let tokio_socket = tokio::net::UdpSocket::bind(&addr)?;
         Ok(Box::pin(UdpSocket { tokio_socket }))
+    }
+
+    fn new_delay(&self, _dur: Duration) -> Pin<Box<dyn runtime_raw::Delay>> {
+        unimplemented!();
+    }
+
+    fn new_delay_at(&self, _dur: Duration) -> Pin<Box<dyn runtime_raw::Delay>> {
+        unimplemented!();
+    }
+
+    fn new_interval(&self, _dur: Duration) -> Pin<Box<dyn runtime_raw::Interval>> {
+        unimplemented!();
     }
 }
 
@@ -142,5 +155,17 @@ impl runtime_raw::Runtime for TokioCurrentThread {
     ) -> io::Result<Pin<Box<dyn runtime_raw::UdpSocket>>> {
         let tokio_socket = tokio::net::UdpSocket::bind(&addr)?;
         Ok(Box::pin(UdpSocket { tokio_socket }))
+    }
+
+    fn new_delay(&self, _dur: Duration) -> Pin<Box<dyn runtime_raw::Delay>> {
+        unimplemented!();
+    }
+
+    fn new_delay_at(&self, _dur: Duration) -> Pin<Box<dyn runtime_raw::Delay>> {
+        unimplemented!();
+    }
+
+    fn new_interval(&self, _dur: Duration) -> Pin<Box<dyn runtime_raw::Interval>> {
+        unimplemented!();
     }
 }

--- a/runtime-tokio/src/time.rs
+++ b/runtime-tokio/src/time.rs
@@ -1,4 +1,3 @@
-use std::fmt;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::Instant;
@@ -7,6 +6,7 @@ use futures::compat::Compat01As03;
 use futures::prelude::*;
 use tokio::timer::{Delay as TokioDelay, Interval as TokioInterval};
 
+#[derive(Debug)]
 pub(crate) struct Delay {
     pub(crate) tokio_delay: TokioDelay,
 }
@@ -24,12 +24,7 @@ impl Future for Delay {
     }
 }
 
-impl fmt::Debug for Delay {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        fmt::Debug::fmt(&self.tokio_delay, f)
-    }
-}
-
+#[derive(Debug)]
 pub(crate) struct Interval {
     pub(crate) tokio_interval: TokioInterval,
 }
@@ -43,13 +38,9 @@ impl Stream for Interval {
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let mut stream = Compat01As03::new(&mut self.tokio_interval);
         // https://docs.rs/tokio/0.1.20/tokio/timer/struct.Error.html
-        futures::ready!(Pin::new(&mut stream).poll_next(cx)).unwrap().unwrap();
+        futures::ready!(Pin::new(&mut stream).poll_next(cx))
+            .unwrap()
+            .unwrap();
         Poll::Ready(Some(Instant::now()))
-    }
-}
-
-impl fmt::Debug for Interval {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        fmt::Debug::fmt(&self.tokio_interval, f)
     }
 }

--- a/runtime-tokio/src/time.rs
+++ b/runtime-tokio/src/time.rs
@@ -1,0 +1,55 @@
+use std::fmt;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Instant;
+
+use futures::compat::Compat01As03;
+use futures::prelude::*;
+use tokio::timer::{Delay as TokioDelay, Interval as TokioInterval};
+
+pub(crate) struct Delay {
+    pub(crate) tokio_delay: TokioDelay,
+}
+
+impl runtime_raw::Delay for Delay {}
+
+impl Future for Delay {
+    type Output = Instant;
+
+    #[inline]
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut fut = Compat01As03::new(&mut self.tokio_delay);
+        futures::ready!(Pin::new(&mut fut).poll(cx)).unwrap();
+        Poll::Ready(Instant::now())
+    }
+}
+
+impl fmt::Debug for Delay {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        fmt::Debug::fmt(&self.tokio_delay, f)
+    }
+}
+
+pub(crate) struct Interval {
+    pub(crate) tokio_interval: TokioInterval,
+}
+
+impl runtime_raw::Interval for Interval {}
+
+impl Stream for Interval {
+    type Item = Instant;
+
+    #[inline]
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut stream = Compat01As03::new(&mut self.tokio_interval);
+        // https://docs.rs/tokio/0.1.20/tokio/timer/struct.Error.html
+        futures::ready!(Pin::new(&mut stream).poll_next(cx)).unwrap().unwrap();
+        Poll::Ready(Some(Instant::now()))
+    }
+}
+
+impl fmt::Debug for Interval {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        fmt::Debug::fmt(&self.tokio_interval, f)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,7 @@
 
 pub mod net;
 pub mod task;
+pub mod time;
 
 #[doc(inline)]
 pub use task::spawn;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,8 @@ pub mod time;
 pub mod prelude {
     #[doc(inline)]
     pub use super::time::FutureExt;
+    #[doc(inline)]
+    pub use super::time::StreamExt;
 }
 
 #[doc(inline)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,11 +113,11 @@ pub mod time;
 /// ```
 pub mod prelude {
     #[doc(inline)]
-    pub use super::time::FutureExt;
+    pub use super::time::AsyncReadTimeExt;
     #[doc(inline)]
-    pub use super::time::StreamExt;
+    pub use super::time::FutureTimeExt;
     #[doc(inline)]
-    pub use super::time::AsyncReadExt;
+    pub use super::time::StreamTimeExt;
 }
 
 #[doc(inline)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,11 +113,11 @@ pub mod time;
 /// ```
 pub mod prelude {
     #[doc(inline)]
-    pub use super::time::AsyncReadTimeExt;
+    pub use super::time::AsyncReadExt as _;
     #[doc(inline)]
-    pub use super::time::FutureTimeExt;
+    pub use super::time::FutureExt as _;
     #[doc(inline)]
-    pub use super::time::StreamTimeExt;
+    pub use super::time::StreamExt as _;
 }
 
 #[doc(inline)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,24 @@ pub mod net;
 pub mod task;
 pub mod time;
 
+/// The Runtime Prelude.
+///
+/// Rust comes with a variety of things in its standard library. However, Runtime and Futures
+/// provide new functionality outside of it. We want to make Runtime feel as close to standard Rust
+/// as possible. We care deeply about usability.
+///
+/// The _prelude_ is the list of things we recommend importing into Runtime programs. It's kept as
+/// small as possible, and is focused on things, particularly traits.
+///
+/// To use the `prelude` do:
+/// ```
+/// use runtime::prelude::*;
+/// ```
+pub mod prelude {
+    #[doc(inline)]
+    pub use super::time::FutureExt;
+}
+
 #[doc(inline)]
 pub use task::spawn;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,8 @@ pub mod prelude {
     pub use super::time::FutureExt;
     #[doc(inline)]
     pub use super::time::StreamExt;
+    #[doc(inline)]
+    pub use super::time::AsyncReadExt;
 }
 
 #[doc(inline)]

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,4 +1,52 @@
-//! Temporal manipulation.
+//! Types and Functions for temporal manipulation.
+//!
+//! This module provides primitives for setting asynchronous timeouts, intervals, and delays.
+//!
+//! # Organization
+//!
+//! * [`Delay`] and [`Interval`] provide functionality for setting delays and intervals.
+//! * [`FutureExt`] extends Futures with the ability to time-out.
+//! * Other types are return or parameter types for various methods in this module
+//!
+//! [`Delay`]: struct.Delay.html
+//! [`Interval`]: struct.Interval.html
+//! [`FutureExt`]: trait.FutureExt.html
+//!
+//! ## Examples
+//! __Schedule a 3-second delay__
+//! ```no_run
+//! # #![feature(async_await)]
+//! # #[runtime::main]
+//! # async fn main() {
+//! use runtime::time::wait_for;
+//! use std::time::{Duration, Instant};
+//!
+//! let start = Instant::now();
+//! let now = wait_for(Duration::from_secs(3)).await;
+//!
+//! let elapsed = now - start;
+//! println!("elapsed: {}s", elapsed.as_secs());
+//! # }
+//! ```
+//!
+//! __Schedule a 2-second interval__
+//! ```ignore
+//! # #![feature(async_await)]
+//! # #[runtime::main]
+//! # async fn main() {
+//! # use futures::for_await;
+//! use runtime::time::repeat;
+//! use std::time::{Duration, Instant};
+//!
+//! let start = Instant::now();
+//!
+//! #[for_await]
+//! for now in repeat(Duration::from_secs(2)) {
+//!     let elapsed = now - start;
+//!     println!("elapsed: {}s", elapsed.as_secs());
+//! }
+//! # }
+//! ```
 
 mod delay;
 mod interval;

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,3 +1,5 @@
+//! Temporal manipulation.
+
 mod delay;
 mod interval;
 

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,0 +1,27 @@
+mod delay;
+mod interval;
+
+pub mod ext;
+
+pub use delay::Delay;
+pub use interval::Interval;
+
+use std::time::{Duration, Instant};
+
+/// Sleep the current future for the given duration.
+#[inline]
+pub fn wait_for(dur: Duration) -> Delay {
+    Delay::new(dur)
+}
+
+/// Sleep the current future until the given time.
+#[inline]
+pub fn wait_until(at: Instant) -> Delay {
+    Delay::new_at(at)
+}
+
+/// Create a stream that fires events at a set interval.
+#[inline]
+pub fn repeat(dur: Duration) -> Interval {
+    Interval::new(dur)
+}

--- a/src/time.rs
+++ b/src/time.rs
@@ -13,7 +13,7 @@
 //! [`FutureExt`]: trait.FutureExt.html
 //!
 //! ## Examples
-//! __Schedule a 3-second delay__
+//! __Schedule a three-second delay__
 //! ```no_run
 //! # #![feature(async_await)]
 //! # #[runtime::main]
@@ -29,7 +29,7 @@
 //! # }
 //! ```
 //!
-//! __Schedule a 2-second interval__
+//! __Schedule a two-second interval__
 //! ```ignore
 //! # #![feature(async_await)]
 //! # #[runtime::main]

--- a/src/time.rs
+++ b/src/time.rs
@@ -13,7 +13,7 @@
 //! [`FutureExt`]: trait.FutureExt.html
 //!
 //! ## Examples
-//! __Schedule a three-second delay__
+//! __Delay execution for three seconds__
 //! ```no_run
 //! # #![feature(async_await)]
 //! # #[runtime::main]
@@ -29,7 +29,7 @@
 //! # }
 //! ```
 //!
-//! __Schedule a two-second interval__
+//! __Emit an event every two seconds__
 //! ```no_run
 //! # #![feature(async_await)]
 //! # #[runtime::main]

--- a/src/time.rs
+++ b/src/time.rs
@@ -18,11 +18,11 @@
 //! # #![feature(async_await)]
 //! # #[runtime::main]
 //! # async fn main() {
-//! use runtime::time::wait_for;
+//! use runtime::time::delay_for;
 //! use std::time::{Duration, Instant};
 //!
 //! let start = Instant::now();
-//! let now = wait_for(Duration::from_secs(3)).await;
+//! let now = delay_for(Duration::from_secs(3)).await;
 //!
 //! let elapsed = now - start;
 //! println!("elapsed: {}s", elapsed.as_secs());
@@ -35,13 +35,13 @@
 //! # #[runtime::main]
 //! # async fn main() {
 //! # use futures::for_await;
-//! use runtime::time::repeat;
+//! use runtime::time::interval;
 //! use std::time::{Duration, Instant};
 //!
 //! let start = Instant::now();
 //!
 //! #[for_await]
-//! for now in repeat(Duration::from_secs(2)) {
+//! for now in interval(Duration::from_secs(2)) {
 //!     let elapsed = now - start;
 //!     println!("elapsed: {}s", elapsed.as_secs());
 //! }
@@ -62,18 +62,18 @@ use std::time::{Duration, Instant};
 
 /// Sleep the current future for the given duration.
 #[inline]
-pub fn wait_for(dur: Duration) -> Delay {
+pub fn delay_for(dur: Duration) -> Delay {
     Delay::new(dur)
 }
 
 /// Sleep the current future until the given time.
 #[inline]
-pub fn wait_until(at: Instant) -> Delay {
+pub fn delay_until(at: Instant) -> Delay {
     Delay::new_at(at)
 }
 
 /// Create a stream that fires events at a set interval.
 #[inline]
-pub fn repeat(dur: Duration) -> Interval {
+pub fn interval(dur: Duration) -> Interval {
     Interval::new(dur)
 }

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,4 +1,4 @@
-//! Types and Functions for temporal manipulation.
+//! Types and Functions for time-related operations.
 //!
 //! This module provides primitives for setting asynchronous timeouts, intervals, and delays.
 //!

--- a/src/time.rs
+++ b/src/time.rs
@@ -6,6 +6,8 @@ mod interval;
 pub mod ext;
 
 pub use delay::Delay;
+#[doc(inline)]
+pub use ext::FutureExt;
 pub use interval::Interval;
 
 use std::time::{Duration, Instant};

--- a/src/time.rs
+++ b/src/time.rs
@@ -61,18 +61,67 @@ pub use interval::Interval;
 use std::time::{Duration, Instant};
 
 /// Sleep the current future for the given duration.
+///
+/// ## Examples
+/// ```
+/// # #![feature(async_await)]
+/// use runtime::time::delay_for;
+/// use std::time::{Duration, Instant};
+///
+/// # #[runtime::main]
+/// # async fn main () -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+/// let start = Instant::now();
+/// let now = delay_for(Duration::from_millis(20)).await;
+///
+/// assert!(now - start >= Duration::from_millis(20));
+/// # Ok(())}
+/// ```
 #[inline]
 pub fn delay_for(dur: Duration) -> Delay {
     Delay::new(dur)
 }
 
 /// Sleep the current future until the given time.
+///
+/// ## Examples
+/// ```
+/// # #![feature(async_await)]
+/// use runtime::time::delay_until;
+/// use std::time::{Duration, Instant};
+///
+/// # #[runtime::main]
+/// # async fn main () -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+/// let start = Instant::now();
+/// let now = delay_until(start + Duration::from_millis(40)).await;
+///
+/// assert!(now - start >= Duration::from_millis(40));
+/// # Ok(())}
+/// ```
 #[inline]
 pub fn delay_until(at: Instant) -> Delay {
     Delay::new_at(at)
 }
 
 /// Create a stream that fires events at a set interval.
+///
+/// ## Examples
+/// ```
+/// # #![feature(async_await)]
+/// # use futures::prelude::*;
+/// use runtime::time::interval;
+/// use std::time::{Duration, Instant};
+///
+/// # #[runtime::main]
+/// # async fn main () -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+/// let start = Instant::now();
+/// let mut interval = interval(Duration::from_millis(10)).take(3);
+/// while let Some(now) = interval.next().await {
+///     println!("{}ms have elapsed", (now - start).as_millis());
+/// }
+///
+/// assert!(Instant::now() - start >= Duration::from_millis(30));
+/// # Ok(())}
+/// ```
 #[inline]
 pub fn interval(dur: Duration) -> Interval {
     Interval::new(dur)

--- a/src/time.rs
+++ b/src/time.rs
@@ -18,11 +18,11 @@
 //! # #![feature(async_await)]
 //! # #[runtime::main]
 //! # async fn main() {
-//! use runtime::time::delay_for;
+//! use runtime::time::Delay;
 //! use std::time::{Duration, Instant};
 //!
 //! let start = Instant::now();
-//! let now = delay_for(Duration::from_secs(3)).await;
+//! let now = Delay::new(Duration::from_secs(3)).await;
 //!
 //! let elapsed = now - start;
 //! println!("elapsed: {}s", elapsed.as_secs());
@@ -30,18 +30,18 @@
 //! ```
 //!
 //! __Schedule a two-second interval__
-//! ```ignore
+//! ```no_run
 //! # #![feature(async_await)]
 //! # #[runtime::main]
 //! # async fn main() {
-//! # use futures::for_await;
-//! use runtime::time::interval;
+//! # use futures::prelude::*;
+//! use runtime::time::Interval;
 //! use std::time::{Duration, Instant};
 //!
 //! let start = Instant::now();
 //!
-//! #[for_await]
-//! for now in interval(Duration::from_secs(2)) {
+//! let mut interval = Interval::new(Duration::from_secs(2));
+//! while let Some(now) = interval.next().await {
 //!     let elapsed = now - start;
 //!     println!("elapsed: {}s", elapsed.as_secs());
 //! }
@@ -50,79 +50,8 @@
 
 mod delay;
 mod interval;
+mod ext;
 
-pub mod ext;
-
-pub use delay::Delay;
-#[doc(inline)]
-pub use ext::FutureExt;
-pub use interval::Interval;
-
-use std::time::{Duration, Instant};
-
-/// Sleep the current future for the given duration.
-///
-/// ## Examples
-/// ```
-/// # #![feature(async_await)]
-/// use runtime::time::delay_for;
-/// use std::time::{Duration, Instant};
-///
-/// # #[runtime::main]
-/// # async fn main () -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-/// let start = Instant::now();
-/// let now = delay_for(Duration::from_millis(20)).await;
-///
-/// assert!(now - start >= Duration::from_millis(20));
-/// # Ok(())}
-/// ```
-#[inline]
-pub fn delay_for(dur: Duration) -> Delay {
-    Delay::new(dur)
-}
-
-/// Sleep the current future until the given time.
-///
-/// ## Examples
-/// ```
-/// # #![feature(async_await)]
-/// use runtime::time::delay_until;
-/// use std::time::{Duration, Instant};
-///
-/// # #[runtime::main]
-/// # async fn main () -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-/// let start = Instant::now();
-/// let now = delay_until(start + Duration::from_millis(40)).await;
-///
-/// assert!(now - start >= Duration::from_millis(40));
-/// # Ok(())}
-/// ```
-#[inline]
-pub fn delay_until(at: Instant) -> Delay {
-    Delay::new_at(at)
-}
-
-/// Create a stream that fires events at a set interval.
-///
-/// ## Examples
-/// ```
-/// # #![feature(async_await)]
-/// # use futures::prelude::*;
-/// use runtime::time::interval;
-/// use std::time::{Duration, Instant};
-///
-/// # #[runtime::main]
-/// # async fn main () -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-/// let start = Instant::now();
-/// let mut interval = interval(Duration::from_millis(10)).take(3);
-/// while let Some(now) = interval.next().await {
-///     println!("{}ms have elapsed", (now - start).as_millis());
-/// }
-///
-/// assert!(Instant::now() - start >= Duration::from_millis(30));
-/// # Ok(())}
-/// ```
-#[inline]
-pub fn interval(dur: Duration) -> Interval {
-    Interval::new(dur)
-}
+pub use delay::*;
+pub use interval::*;
+pub use ext::*;

--- a/src/time.rs
+++ b/src/time.rs
@@ -49,9 +49,9 @@
 //! ```
 
 mod delay;
-mod interval;
 mod ext;
+mod interval;
 
 pub use delay::*;
-pub use interval::*;
 pub use ext::*;
+pub use interval::*;

--- a/src/time/delay.rs
+++ b/src/time/delay.rs
@@ -58,8 +58,8 @@ impl Delay {
 }
 
 impl fmt::Debug for Delay {
-    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        unimplemented!();
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        fmt::Debug::fmt(&self.inner, f)
     }
 }
 

--- a/src/time/delay.rs
+++ b/src/time/delay.rs
@@ -1,0 +1,37 @@
+use futures::prelude::*;
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::{Duration, Instant};
+
+/// A future representing the notification that an elapsed duration has occurred.
+#[must_use = "futures do nothing unless awaited"]
+#[derive(Debug)]
+pub struct Delay {
+    inner: Pin<Box<dyn runtime_raw::Delay>>,
+}
+
+impl Delay {
+    /// Sleep the current future for the given duration.
+    #[inline]
+    pub fn new(dur: Duration) -> Self {
+        let inner = runtime_raw::new_delay(dur);
+        Self { inner }
+    }
+
+    /// Sleep the current future until the given time.
+    #[inline]
+    pub fn new_at(at: Instant) -> Self {
+        let inner = runtime_raw::new_delay_at(dur);
+        Self { inner }
+    }
+}
+
+impl Future for Delay {
+    type Output = Instant;
+
+    #[inline]
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.inner.as_mut().poll(cx)
+    }
+}

--- a/src/time/delay.rs
+++ b/src/time/delay.rs
@@ -1,9 +1,9 @@
 use futures::prelude::*;
 
+use std::fmt;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
-use std::fmt;
 
 /// A future representing the notification that an elapsed duration has occurred.
 #[must_use = "futures do nothing unless awaited"]

--- a/src/time/delay.rs
+++ b/src/time/delay.rs
@@ -3,10 +3,10 @@ use futures::prelude::*;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
+use std::fmt;
 
 /// A future representing the notification that an elapsed duration has occurred.
 #[must_use = "futures do nothing unless awaited"]
-#[derive(Debug)]
 pub struct Delay {
     inner: Pin<Box<dyn runtime_raw::Delay>>,
 }
@@ -15,15 +15,21 @@ impl Delay {
     /// Sleep the current future for the given duration.
     #[inline]
     pub fn new(dur: Duration) -> Self {
-        let inner = runtime_raw::new_delay(dur);
+        let inner = runtime_raw::current_runtime().new_delay(dur);
         Self { inner }
     }
 
     /// Sleep the current future until the given time.
     #[inline]
     pub fn new_at(at: Instant) -> Self {
-        let inner = runtime_raw::new_delay_at(dur);
+        let inner = runtime_raw::current_runtime().new_delay_at(at);
         Self { inner }
+    }
+}
+
+impl fmt::Debug for Delay {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        unimplemented!();
     }
 }
 
@@ -31,7 +37,7 @@ impl Future for Delay {
     type Output = Instant;
 
     #[inline]
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        self.inner.as_mut().poll(cx)
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.inner.poll_unpin(cx)
     }
 }

--- a/src/time/delay.rs
+++ b/src/time/delay.rs
@@ -12,14 +12,44 @@ pub struct Delay {
 }
 
 impl Delay {
-    /// Sleep the current future for the given duration.
+    /// Continue execution after the duration has passed.
+    ///
+    /// ## Examples
+    /// ```
+    /// # #![feature(async_await)]
+    /// use runtime::time::Delay;
+    /// use std::time::{Duration, Instant};
+    ///
+    /// # #[runtime::main]
+    /// # async fn main () -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    /// let start = Instant::now();
+    /// let now = Delay::new(Duration::from_millis(40)).await;
+    ///
+    /// assert!(now - start >= Duration::from_millis(40));
+    /// # Ok(())}
+    /// ```
     #[inline]
     pub fn new(dur: Duration) -> Self {
         let inner = runtime_raw::current_runtime().new_delay(dur);
         Self { inner }
     }
 
-    /// Sleep the current future until the given time.
+    /// Continue execution after the given instant.
+    ///
+    /// ## Examples
+    /// ```
+    /// # #![feature(async_await)]
+    /// use runtime::time::Delay;
+    /// use std::time::{Duration, Instant};
+    ///
+    /// # #[runtime::main]
+    /// # async fn main () -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    /// let start = Instant::now();
+    /// let now = Delay::new_at(start + Duration::from_millis(40)).await;
+    ///
+    /// assert!(now - start >= Duration::from_millis(40));
+    /// # Ok(())}
+    /// ```
     #[inline]
     pub fn new_at(at: Instant) -> Self {
         let inner = runtime_raw::current_runtime().new_delay_at(at);

--- a/src/time/ext.rs
+++ b/src/time/ext.rs
@@ -56,7 +56,39 @@ impl fmt::Display for TimeoutError {
 
 /// Extend `Future` with methods to time out execution.
 pub trait FutureExt: Future + Sized {
-    /// Time out the future if it isn't completed after `dur` duration.
+    /// Creates a new future which will take at most `dur` time to resolve from
+    /// the point at which this method is called.
+    ///
+    /// This combinator creates a new future which wraps the receiving future
+    /// in a timeout. The future returned will resolve in at most `dur` time
+    /// specified (relative to when this function is called).
+    ///
+    /// If the future completes before `dur` elapses then the future will
+    /// resolve with that item. Otherwise the future will resolve to an error
+    /// once `dur` has elapsed.
+    ///
+    /// # Examples
+    /// ```
+    /// # #![feature(async_await)]
+    /// # use futures::prelude::*;
+    /// use std::time::Duration;
+    /// use runtime::time::FutureExt;
+    ///
+    /// # fn long_future() -> impl Future<Output = std::io::Result<()>> {
+    /// #     futures::future::ok(())
+    /// # }
+    /// #
+    /// #[runtime::main]
+    /// async fn main() {
+    ///     let future = long_future();
+    ///     let timed_out = future.timeout(Duration::from_millis(100));
+    ///
+    ///     match timed_out.await {
+    ///         Ok(item) => println!("got {:?} within enough time!", item),
+    ///         Err(_) => println!("took too long to produce the item"),
+    ///     }
+    /// }
+    /// ```
     fn timeout(self, dur: Duration) -> Timeout<Self> {
         Timeout {
             delay: Delay::new(dur),
@@ -64,7 +96,38 @@ pub trait FutureExt: Future + Sized {
         }
     }
 
-    /// Time out the future if it isn't completed before `at`.
+    /// Creates a new future which will resolve no later than `at` specified.
+    ///
+    /// This method is otherwise equivalent to the [`timeout`] method except that
+    /// it tweaks the moment at when the timeout elapsed to being specified with
+    /// an absolute value rather than a relative one. For more documentation see
+    /// the [`timeout`] method.
+    ///
+    /// [`timeout`]: trait.FutureExt.html#method.timeout
+    ///
+    /// # Examples
+    /// ```
+    /// # #![feature(async_await)]
+    /// # use futures::prelude::*;
+    /// use std::time::{Duration, Instant};
+    /// use runtime::time::FutureExt;
+    ///
+    /// # fn long_future() -> impl Future<Output = std::io::Result<()>> {
+    /// #     futures::future::ok(())
+    /// # }
+    /// #
+    /// #[runtime::main]
+    /// async fn main() {
+    ///     let future = long_future();
+    ///     let at = Instant::now() + Duration::from_millis(100);
+    ///     let timed_out = future.timeout_at(at);
+    ///
+    ///     match timed_out.await {
+    ///         Ok(item) => println!("got {:?} within enough time!", item),
+    ///         Err(_) => println!("took too long to produce the item"),
+    ///     }
+    /// }
+    /// ```
     fn timeout_at(self, at: Instant) -> Timeout<Self> {
         Timeout {
             delay: Delay::new_at(at),
@@ -72,3 +135,5 @@ pub trait FutureExt: Future + Sized {
         }
     }
 }
+
+impl<T: Future> FutureExt for T {}

--- a/src/time/ext.rs
+++ b/src/time/ext.rs
@@ -1,54 +1,74 @@
 //! Extensions for Futures types.
 
 use std::error::Error;
-use std::fmt::{self, Debug, Display};
+use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 
+use super::Delay;
+
 /// The Future returned from [`FutureExt`].
 ///
 /// [`FutureExt.timeout`]: trait.FutureExt.html
 #[derive(Debug)]
-pub struct Timeout<T> {
-    _phantom: std::marker::PhantomData<T>,
+pub struct Timeout<F: Future> {
+    future: F,
+    delay: Delay,
 }
 
-impl<T: Future> Future for Timeout<T> {
-    type Output = Result<<T as Future>::Output, TimeoutError>;
-    fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
-        unimplemented!();
+impl<F: Future> Timeout<F> {
+    pin_utils::unsafe_pinned!(future: F);
+    pin_utils::unsafe_pinned!(delay: Delay);
+}
+
+impl<F: Future> Future for Timeout<F> {
+    type Output = Result<F::Output, TimeoutError>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.as_mut().future().poll(cx) {
+            Poll::Pending => {}
+            Poll::Ready(t) => return Poll::Ready(Ok(t)),
+        }
+
+        if self.as_mut().poll(cx).is_ready() {
+            let err = Err(TimeoutError(Instant::now()));
+            Poll::Ready(err)
+        } else {
+            Poll::Pending
+        }
     }
 }
 
 /// The Error returned from [`Timeout`].
 ///
 /// [`Timeout`]: struct.Timeout.html
+#[derive(Debug)]
 pub struct TimeoutError(pub Instant);
 impl Error for TimeoutError {}
 
-impl Debug for TimeoutError {
-    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        unimplemented!();
-    }
-}
-
-impl Display for TimeoutError {
-    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        unimplemented!();
+impl fmt::Display for TimeoutError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        fmt::Debug::fmt(self, f)
     }
 }
 
 /// Extend `Future` with methods to time out execution.
 pub trait FutureExt: Future + Sized {
-    /// Timeout the future if it isn't completed after `dur` duration.
-    fn timeout(self, _dur: Duration) -> Timeout<Self> {
-        unimplemented!();
+    /// Time out the future if it isn't completed after `dur` duration.
+    fn timeout(self, dur: Duration) -> Timeout<Self> {
+        Timeout {
+            delay: Delay::new(dur),
+            future: self,
+        }
     }
 
-    /// Timeout the future if it isn't completed by `at`.
-    fn deadline(self, _at: Instant) -> Timeout<Self> {
-        unimplemented!();
+    /// Time out the future if it isn't completed before `at`.
+    fn timeout_at(self, at: Instant) -> Timeout<Self> {
+        Timeout {
+            delay: Delay::new_at(at),
+            future: self,
+        }
     }
 }

--- a/src/time/ext.rs
+++ b/src/time/ext.rs
@@ -116,7 +116,7 @@ pub trait FutureExt: Future + Sized + Unpin {
     }
 }
 
-impl<T: Future> FutureExt for T {}
+impl<T: Future + Unpin> FutureExt for T {}
 
 /// A stream returned by methods in the [`StreamExt`] trait.
 ///

--- a/src/time/ext.rs
+++ b/src/time/ext.rs
@@ -270,20 +270,13 @@ pub trait AsyncReadTimeExt: AsyncRead + Sized {
     /// # async fn main () -> Result<(), Box<dyn std::error::Error + 'static + Send + Sync>> {
     /// use futures::prelude::*;
     /// use runtime::prelude::*;
-    /// use runtime::net::TcpListener;
+    /// use runtime::net::TcpStream;
     /// use std::time::{Duration, Instant};
     ///
     /// let start = Instant::now();
     ///
-    /// let mut listener = TcpListener::bind("127.0.0.1:0")?;
-    /// let mut incoming = listener.incoming()
-    ///     .timeout(Duration::from_millis(100));
-    /// while let Some(stream) = incoming.next().await {
-    ///     match stream {
-    ///         Ok(stream) => println!("new client!"),
-    ///         Err(e) => { /* connection failed */ }
-    ///     }
-    /// }
+    /// let stream = TcpStream::connect("127.0.0.1:8080").await?;
+    /// let _stream = stream.timeout(Duration::from_millis(100));
     /// # Ok(())}
     /// ```
     fn timeout(self, dur: Duration) -> TimeoutAsyncRead<Self> {

--- a/src/time/ext.rs
+++ b/src/time/ext.rs
@@ -203,10 +203,7 @@ impl<S: Stream> TimeoutStream<S> {
 impl<S: Stream> Stream for TimeoutStream<S> {
     type Item = Result<S::Item, TimeoutError>;
 
-    fn poll_next(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<Self::Item>> {
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         match self.as_mut().stream().poll_next(cx) {
             Poll::Pending => {}
             Poll::Ready(s) => {

--- a/src/time/ext.rs
+++ b/src/time/ext.rs
@@ -7,7 +7,9 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 
-/// The Future returned from [`FutureExt.timeout`].
+/// The Future returned from [`FutureExt`].
+///
+/// [`FutureExt.timeout`]: trait.FutureExt.html
 #[derive(Debug)]
 pub struct Timeout<T> {
     _phantom: std::marker::PhantomData<T>,
@@ -20,7 +22,9 @@ impl<T: Future> Future for Timeout<T> {
     }
 }
 
-/// The Error returned in the Future returned from [`FutureExt.timeout`].
+/// The Error returned from [`Timeout`].
+///
+/// [`Timeout`]: struct.Timeout.html
 pub struct TimeoutError(pub Instant);
 impl Error for TimeoutError {}
 

--- a/src/time/ext.rs
+++ b/src/time/ext.rs
@@ -1,0 +1,50 @@
+//! Extensions for Futures types.
+
+use std::error::Error;
+use std::fmt::{self, Debug, Display};
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::{Duration, Instant};
+
+/// The Future returned from [`FutureExt.timeout`].
+#[derive(Debug)]
+pub struct Timeout<T> {
+    _phantom: std::marker::PhantomData<T>,
+}
+
+impl<T: Future> Future for Timeout<T> {
+    type Output = Result<<T as Future>::Output, TimeoutError>;
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        unimplemented!();
+    }
+}
+
+/// The Error returned in the Future returned from [`FutureExt.timeout`].
+pub struct TimeoutError(pub Instant);
+impl Error for TimeoutError {}
+
+impl Debug for TimeoutError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        unimplemented!();
+    }
+}
+
+impl Display for TimeoutError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        unimplemented!();
+    }
+}
+
+/// Extend `Future` with methods to time out execution.
+pub trait FutureExt: Future + Sized {
+    /// Timeout the future if it isn't completed after `dur` duration.
+    fn timeout(self, dur: Duration) -> Timeout<Self> {
+        unimplemented!();
+    }
+
+    /// Timeout the future if it isn't completed by `at`.
+    fn deadline(self, at: Instant) -> Timeout<Self> {
+        unimplemented!();
+    }
+}

--- a/src/time/ext.rs
+++ b/src/time/ext.rs
@@ -15,7 +15,7 @@ use super::Delay;
 ///
 /// [`FutureExt.timeout`]: trait.FutureExt.html
 #[derive(Debug)]
-pub struct Timeout<F: Future> {
+pub struct Timeout<F: Future + Unpin> {
     future: F,
     delay: Delay,
 }
@@ -35,7 +35,7 @@ impl<F: Future + Unpin> Future for Timeout<F> {
 }
 
 /// Extend `Future` with methods to time out execution.
-pub trait FutureExt: Future + Sized {
+pub trait FutureExt: Future + Sized + Unpin {
     /// Creates a new future which will take at most `dur` time to resolve from
     /// the point at which this method is called.
     ///

--- a/src/time/ext.rs
+++ b/src/time/ext.rs
@@ -188,10 +188,9 @@ pub trait StreamTimeExt: Stream + Sized {
     /// # #[runtime::main]
     /// # async fn main () -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// let start = Instant::now();
-    /// let timeout = Duration::from_millis(15);
     /// let mut interval = Interval::new(Duration::from_millis(10))
     ///     .take(3)
-    ///     .timeout(timeout);
+    ///     .timeout(Duration::from_millis(15));
     /// while let Some(now) = interval.next().await {
     ///     println!("{}ms have elapsed", (now? - start).as_millis());
     /// }
@@ -277,7 +276,8 @@ pub trait AsyncReadTimeExt: AsyncRead + Sized {
     /// let start = Instant::now();
     ///
     /// let mut listener = TcpListener::bind("127.0.0.1:0")?;
-    /// let mut incoming = listener.incoming();
+    /// let mut incoming = listener.incoming()
+    ///     .timeout(Duration::from_millis(100));
     /// while let Some(stream) = incoming.next().await {
     ///     match stream {
     ///         Ok(stream) => println!("new client!"),

--- a/src/time/ext.rs
+++ b/src/time/ext.rs
@@ -15,7 +15,7 @@ pub struct Timeout<T> {
 
 impl<T: Future> Future for Timeout<T> {
     type Output = Result<<T as Future>::Output, TimeoutError>;
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
         unimplemented!();
     }
 }
@@ -25,13 +25,13 @@ pub struct TimeoutError(pub Instant);
 impl Error for TimeoutError {}
 
 impl Debug for TimeoutError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         unimplemented!();
     }
 }
 
 impl Display for TimeoutError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         unimplemented!();
     }
 }
@@ -39,12 +39,12 @@ impl Display for TimeoutError {
 /// Extend `Future` with methods to time out execution.
 pub trait FutureExt: Future + Sized {
     /// Timeout the future if it isn't completed after `dur` duration.
-    fn timeout(self, dur: Duration) -> Timeout<Self> {
+    fn timeout(self, _dur: Duration) -> Timeout<Self> {
         unimplemented!();
     }
 
     /// Timeout the future if it isn't completed by `at`.
-    fn deadline(self, at: Instant) -> Timeout<Self> {
+    fn deadline(self, _at: Instant) -> Timeout<Self> {
         unimplemented!();
     }
 }

--- a/src/time/ext.rs
+++ b/src/time/ext.rs
@@ -10,9 +10,9 @@ use futures::{AsyncRead, Stream};
 
 use super::Delay;
 
-/// A future returned by methods in the [`FutureTimeExt`] trait.
+/// A future returned by methods in the [`FutureExt`] trait.
 ///
-/// [`FutureTimeExt.timeout`]: trait.FutureTimeExt.html
+/// [`FutureExt.timeout`]: trait.FutureExt.html
 #[derive(Debug)]
 pub struct Timeout<F: Future> {
     future: F,
@@ -43,7 +43,7 @@ impl<F: Future> Future for Timeout<F> {
 }
 
 /// Extend `Future` with methods to time out execution.
-pub trait FutureTimeExt: Future + Sized {
+pub trait FutureExt: Future + Sized {
     /// Creates a new future which will take at most `dur` time to resolve from
     /// the point at which this method is called.
     ///
@@ -91,7 +91,7 @@ pub trait FutureTimeExt: Future + Sized {
     /// an absolute value rather than a relative one. For more documentation see
     /// the [`timeout`] method.
     ///
-    /// [`timeout`]: trait.FutureTimeExt.html#method.timeout
+    /// [`timeout`]: trait.FutureExt.html#method.timeout
     ///
     /// # Examples
     /// ```
@@ -124,11 +124,11 @@ pub trait FutureTimeExt: Future + Sized {
     }
 }
 
-impl<T: Future> FutureTimeExt for T {}
+impl<T: Future> FutureExt for T {}
 
-/// A stream returned by methods in the [`StreamTimeExt`] trait.
+/// A stream returned by methods in the [`StreamExt`] trait.
 ///
-/// [`StreamTimeExt`]: trait.StreamTimeExt.html
+/// [`StreamExt`]: trait.StreamExt.html
 #[derive(Debug)]
 pub struct TimeoutStream<S: Stream> {
     timeout: Delay,
@@ -165,7 +165,7 @@ impl<S: Stream> Stream for TimeoutStream<S> {
 }
 
 /// Extend `Stream` with methods to time out execution.
-pub trait StreamTimeExt: Stream + Sized {
+pub trait StreamExt: Stream + Sized {
     /// Creates a new stream which will take at most `dur` time to yield each
     /// item of the stream.
     ///
@@ -182,7 +182,7 @@ pub trait StreamTimeExt: Stream + Sized {
     /// ```
     /// # #![feature(async_await)]
     /// # use futures::prelude::*;
-    /// use runtime::time::{Interval, StreamTimeExt as _};
+    /// use runtime::time::{Interval, StreamExt as _};
     /// use std::time::{Duration, Instant};
     ///
     /// # #[runtime::main]
@@ -207,11 +207,11 @@ pub trait StreamTimeExt: Stream + Sized {
     }
 }
 
-impl<S: Stream> StreamTimeExt for S {}
+impl<S: Stream> StreamExt for S {}
 
-/// A stream returned by methods in the [`StreamTimeExt`] trait.
+/// A stream returned by methods in the [`StreamExt`] trait.
 ///
-/// [`StreamTimeExt`]: trait.StreamTimeExt.html
+/// [`StreamExt`]: trait.StreamExt.html
 #[derive(Debug)]
 pub struct TimeoutAsyncRead<S: AsyncRead> {
     timeout: Delay,
@@ -249,7 +249,7 @@ impl<S: AsyncRead> AsyncRead for TimeoutAsyncRead<S> {
 }
 
 /// Extend `AsyncRead` with methods to time out execution.
-pub trait AsyncReadTimeExt: AsyncRead + Sized {
+pub trait AsyncReadExt: AsyncRead + Sized {
     /// Creates a new stream which will take at most `dur` time to yield each
     /// item of the stream.
     ///
@@ -288,4 +288,4 @@ pub trait AsyncReadTimeExt: AsyncRead + Sized {
     }
 }
 
-impl<S: AsyncRead> AsyncReadTimeExt for S {}
+impl<S: AsyncRead> AsyncReadExt for S {}

--- a/src/time/interval.rs
+++ b/src/time/interval.rs
@@ -1,9 +1,9 @@
 use futures::prelude::*;
 
+use std::fmt;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
-use std::fmt;
 
 /// A stream representing notifications at a fixed interval.
 #[must_use = "streams do nothing unless polled"]

--- a/src/time/interval.rs
+++ b/src/time/interval.rs
@@ -15,7 +15,7 @@ impl Interval {
     /// Create a stream that fires events at a set interval.
     #[inline]
     pub fn new(dur: Duration) -> Self {
-        let inner = runtime_raw::new_interval(dur);
+        let inner = runtime_raw::current_runtime().new_interval(dur);
         Self { inner }
     }
 }
@@ -24,7 +24,7 @@ impl Stream for Interval {
     type Item = Instant;
 
     #[inline]
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        self.inner.as_mut().poll_next(cx)
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.inner.poll_next_unpin(cx)
     }
 }

--- a/src/time/interval.rs
+++ b/src/time/interval.rs
@@ -1,0 +1,30 @@
+use futures::prelude::*;
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::{Duration, Instant};
+
+/// A stream representing notifications at a fixed interval.
+#[must_use = "streams do nothing unless polled"]
+#[derive(Debug)]
+pub struct Interval {
+    inner: Pin<Box<dyn runtime_raw::Interval>>,
+}
+
+impl Interval {
+    /// Create a stream that fires events at a set interval.
+    #[inline]
+    pub fn new(dur: Duration) -> Self {
+        let inner = runtime_raw::new_interval(dur);
+        Self { inner }
+    }
+}
+
+impl Stream for Interval {
+    type Item = Instant;
+
+    #[inline]
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.inner.as_mut().poll_next(cx)
+    }
+}

--- a/src/time/interval.rs
+++ b/src/time/interval.rs
@@ -13,6 +13,25 @@ pub struct Interval {
 
 impl Interval {
     /// Create a stream that fires events at a set interval.
+    ///
+    /// ## Examples
+    /// ```
+    /// # #![feature(async_await)]
+    /// # use futures::prelude::*;
+    /// use runtime::time::Interval;
+    /// use std::time::{Duration, Instant};
+    ///
+    /// # #[runtime::main]
+    /// # async fn main () -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    /// let start = Instant::now();
+    /// let mut interval = Interval::new(Duration::from_millis(10)).take(3);
+    /// while let Some(now) = interval.next().await {
+    ///     println!("{}ms have elapsed", (now - start).as_millis());
+    /// }
+    ///
+    /// assert!(Instant::now() - start >= Duration::from_millis(30));
+    /// # Ok(())}
+    /// ```
     #[inline]
     pub fn new(dur: Duration) -> Self {
         let inner = runtime_raw::current_runtime().new_interval(dur);

--- a/src/time/interval.rs
+++ b/src/time/interval.rs
@@ -3,10 +3,10 @@ use futures::prelude::*;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
+use std::fmt;
 
 /// A stream representing notifications at a fixed interval.
 #[must_use = "streams do nothing unless polled"]
-#[derive(Debug)]
 pub struct Interval {
     inner: Pin<Box<dyn runtime_raw::Interval>>,
 }
@@ -45,5 +45,11 @@ impl Stream for Interval {
     #[inline]
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         self.inner.poll_next_unpin(cx)
+    }
+}
+
+impl fmt::Debug for Interval {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        fmt::Debug::fmt(&self.inner, f)
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds the `runtime::time` submodule.

```rust
use runtime::time::{Delay, Interval};
use std::time::Duration::SECONDS;

#[runtime::main]
async fn main() {
    println!("start");
    Delay::new(6 * SECONDS).await;
    
    #[runtime::for_await]
    for now in Interval::repeat(5 * SECONDS).take(3) {
        println!("5 secs have passed");
    }

    println!("done");
}
```

![Screenshot_2019-05-18 runtime time - Rust](https://user-images.githubusercontent.com/2467194/57974650-30242b00-79bc-11e9-9638-59316120da30.png)

## Todos
- [x] docs
- [x] remove unwraps
- [x] tokio implementation
- [x]  finish debug impls
- [x] finish the ext traits

## Motivation and Context
Implements #14. Depends on https://github.com/rustasync/futures-timer/pull/13.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
