### PR TITLE
Renamed all types that return a Future to have the suffix of 'Future'

### DIFF
--- a/src/task.rs
+++ b/src/task.rs
@@ -23,7 +23,7 @@ use futures::task::{Context, Poll};
 ///     assert_eq!(handle.await, 42);
 /// }
 /// ```
-pub fn spawn<F, T>(fut: F) -> JoinHandle<T>
+pub fn spawn<F, T>(fut: F) -> JoinHandleFuture<T>
 where
     F: Future<Output = T> + Send + 'static,
     T: Send + 'static,
@@ -39,7 +39,7 @@ where
         .spawn_boxed(fut.boxed())
         .expect("cannot spawn a future");
 
-    JoinHandle { rx }
+    JoinHandleFuture { rx }
 }
 
 /// A handle that awaits the result of a [`spawn`]ed future.
@@ -47,11 +47,11 @@ where
 /// [`spawn`]: fn.spawn.html
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 #[derive(Debug)]
-pub struct JoinHandle<T> {
+pub struct JoinHandleFuture<T> {
     pub(crate) rx: futures::channel::oneshot::Receiver<T>,
 }
 
-impl<T> Future for JoinHandle<T> {
+impl<T> Future for JoinHandleFuture<T> {
     type Output = T;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {

--- a/src/task.rs
+++ b/src/task.rs
@@ -23,7 +23,7 @@ use futures::task::{Context, Poll};
 ///     assert_eq!(handle.await, 42);
 /// }
 /// ```
-pub fn spawn<F, T>(fut: F) -> JoinHandleFuture<T>
+pub fn spawn<F, T>(fut: F) -> JoinHandle<T>
 where
     F: Future<Output = T> + Send + 'static,
     T: Send + 'static,
@@ -39,7 +39,7 @@ where
         .spawn_boxed(fut.boxed())
         .expect("cannot spawn a future");
 
-    JoinHandleFuture { rx }
+    JoinHandle { rx }
 }
 
 /// A handle that awaits the result of a [`spawn`]ed future.
@@ -47,11 +47,11 @@ where
 /// [`spawn`]: fn.spawn.html
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 #[derive(Debug)]
-pub struct JoinHandleFuture<T> {
+pub struct JoinHandle<T> {
     pub(crate) rx: futures::channel::oneshot::Receiver<T>,
 }
 
-impl<T> Future for JoinHandleFuture<T> {
+impl<T> Future for JoinHandle<T> {
     type Output = T;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {


### PR DESCRIPTION
This is in preparation for filesystem support where that is the only logical pattern.
For example Connect (the struct returned from TcpStream::connect(..)) returns
a ConnectFuture instead of the original Connect. Closes: #40

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Simply renamed the structs returned by functions that are returning futures (and streams).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It was requested.

<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/rustasync/runtime/issues/40

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
