### PR TITLE
remove spawn from top-level

### DIFF
--- a/benches/common/mod.rs
+++ b/benches/common/mod.rs
@@ -30,7 +30,7 @@ macro_rules! benchmark_suite {
 
             let tasks = (0..300)
                 .map(|_| {
-                    runtime::spawn(async {
+                    runtime::task::spawn(async {
                         Task { depth: 0 }.await;
                     })
                 })
@@ -44,7 +44,7 @@ macro_rules! benchmark_suite {
         #[runtime::bench($rt)]
         async fn spawn_many() {
             let tasks = (0..25_000)
-                .map(|_| runtime::spawn(async {}))
+                .map(|_| runtime::task::spawn(async {}))
                 .collect::<Vec<_>>();
 
             for task in tasks {
@@ -61,7 +61,7 @@ macro_rules! benchmark_suite {
 
             let tasks = (0..300)
                 .map(|_| {
-                    runtime::spawn(async {
+                    runtime::task::spawn(async {
                         let (r, s) = mio::Registration::new2();
                         let registration = Registration::new();
                         registration.register(&r).unwrap();
@@ -69,7 +69,7 @@ macro_rules! benchmark_suite {
                         let mut depth = 0;
                         let mut capture = Some(r);
 
-                        runtime::spawn(
+                        runtime::task::spawn(
                             Compat01As03::new(future::poll_fn(move || loop {
                                 if registration.poll_read_ready().unwrap().is_ready() {
                                     depth += 1;

--- a/examples/guessing.rs
+++ b/examples/guessing.rs
@@ -64,7 +64,7 @@ async fn main() -> Result<(), failure::Error> {
     let incoming = listener.incoming().map_err(|e| e.into());
     incoming
         .try_for_each_concurrent(None, async move |stream| {
-            runtime::spawn(play(stream)).await?;
+            runtime::task::spawn(play(stream)).await?;
             Ok::<(), failure::Error>(())
         })
         .await?;

--- a/examples/tcp-echo.rs
+++ b/examples/tcp-echo.rs
@@ -17,7 +17,7 @@ async fn main() -> std::io::Result<()> {
     listener
         .incoming()
         .try_for_each_concurrent(None, async move |stream| {
-            runtime::spawn(async move {
+            runtime::task::spawn(async move {
                 println!("Accepting from: {}", stream.peer_addr()?);
 
                 let (reader, writer) = &mut stream.split();

--- a/examples/tcp-proxy.rs
+++ b/examples/tcp-proxy.rs
@@ -15,7 +15,7 @@ async fn main() -> std::io::Result<()> {
     listener
         .incoming()
         .try_for_each_concurrent(None, async move |client| {
-            runtime::spawn(async move {
+            runtime::task::spawn(async move {
                 let server = TcpStream::connect("127.0.0.1:8080").await?;
                 println!(
                     "Proxying {} to {}",

--- a/runtime-attributes/src/lib.rs
+++ b/runtime-attributes/src/lib.rs
@@ -126,7 +126,7 @@ pub fn test(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// #[runtime::test]
 /// async fn spawn_and_await() {
-///   runtime::spawn(async {}).await;
+///   runtime::task::spawn(async {}).await;
 /// }
 /// ```
 #[proc_macro_attribute]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,9 +121,6 @@ pub mod prelude {
 }
 
 #[doc(inline)]
-pub use task::spawn;
-
-#[doc(inline)]
 pub use runtime_attributes::{bench, test};
 
 #[doc(inline)]

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -304,7 +304,7 @@ impl fmt::Debug for ConnectFuture {
 ///     // accept connections and process them in parallel
 ///     let mut incoming = listener.incoming();
 ///     while let Some(stream) = incoming.next().await {
-///         runtime::spawn(async move {
+///         runtime::task::spawn(async move {
 ///             let stream = stream?;
 ///             println!("Accepting from: {}", stream.peer_addr()?);
 ///

--- a/src/task.rs
+++ b/src/task.rs
@@ -16,7 +16,7 @@ use futures::task::{Context, Poll};
 ///
 /// #[runtime::main]
 /// async fn main() {
-///     let handle = runtime::spawn(async {
+///     let handle = runtime::task::spawn(async {
 ///         println!("running the future");
 ///         42
 ///     });

--- a/tests/native.rs
+++ b/tests/native.rs
@@ -4,7 +4,7 @@ use runtime_native::Native;
 
 #[runtime::test(Native)]
 async fn spawn() {
-    let handle = runtime::spawn(async {
+    let handle = runtime::task::spawn(async {
         println!("hello planet from Native");
         42
     });

--- a/tests/tokio-current-thread.rs
+++ b/tests/tokio-current-thread.rs
@@ -2,7 +2,7 @@
 
 #[runtime::test(runtime_tokio::TokioCurrentThread)]
 async fn spawn() {
-    let handle = runtime::spawn(async {
+    let handle = runtime::task::spawn(async {
         println!("hello planet from Tokio current-thread");
         42
     });

--- a/tests/tokio.rs
+++ b/tests/tokio.rs
@@ -4,7 +4,7 @@ use runtime_tokio::Tokio;
 
 #[runtime::test(Tokio)]
 async fn spawn() {
-    let handle = runtime::spawn(async {
+    let handle = runtime::task::spawn(async {
         println!("hello planet from Tokio");
         42
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This removes the spawn function from the top-level exports

Instead `task::spawn` should be used. If this were part of std, `spawn`
wouldn't be a top-level method, so we should keep it in `task` instead.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)