### PR TITLE
Time module polish

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -49,9 +49,12 @@
 //! ```
 
 mod delay;
-mod ext;
 mod interval;
 
+pub mod ext;
+
 pub use delay::*;
-pub use ext::*;
 pub use interval::*;
+
+#[doc(inline)]
+pub use ext::{FutureExt, StreamExt, AsyncReadExt};

--- a/src/time.rs
+++ b/src/time.rs
@@ -49,12 +49,9 @@
 //! ```
 
 mod delay;
+mod ext;
 mod interval;
 
-pub mod ext;
-
 pub use delay::*;
+pub use ext::*;
 pub use interval::*;
-
-#[doc(inline)]
-pub use ext::{FutureExt, StreamExt, AsyncReadExt};

--- a/src/time/ext.rs
+++ b/src/time/ext.rs
@@ -34,7 +34,9 @@ impl<F: Future + Unpin> Future for TimeoutFuture<F> {
     }
 }
 
-/// Extend `Future` with methods to time out execution.
+/// Extend [`Future`] with methods to time out execution.
+///
+/// [`Future`]: https://doc.rust-lang.org/std/future/trait.Future.html
 pub trait FutureExt: Future + Sized + Unpin {
     /// Creates a new future which will take at most `dur` time to resolve from
     /// the point at which this method is called.
@@ -147,7 +149,9 @@ impl<S: Stream + Unpin> Stream for TimeoutStream<S> {
     }
 }
 
-/// Extend `Stream` with methods to time out execution.
+/// Extend [`Stream`] with methods to time out execution.
+///
+/// [`Stream`]: https://docs.rs/futures-preview/0.3.0-alpha.16/futures/stream/trait.Stream.html
 pub trait StreamExt: Stream + Sized + Unpin {
     /// Creates a new stream which will take at most `dur` time to yield each
     /// item of the stream.
@@ -220,7 +224,9 @@ impl<S: AsyncRead + Unpin> AsyncRead for TimeoutAsyncRead<S> {
     }
 }
 
-/// Extend `AsyncRead` with methods to time out execution.
+/// Extend [`AsyncRead`] with methods to time out execution.
+///
+/// [`AsyncRead`]: https://docs.rs/futures-preview/0.3.0-alpha.16/futures/io/trait.AsyncRead.html?search=
 pub trait AsyncReadExt: AsyncRead + Sized + Unpin {
     /// Creates a new stream which will take at most `dur` time to yield each
     /// item of the stream.

--- a/src/time/ext.rs
+++ b/src/time/ext.rs
@@ -15,12 +15,12 @@ use super::Delay;
 ///
 /// [`FutureExt.timeout`]: trait.FutureExt.html
 #[derive(Debug)]
-pub struct Timeout<F: Future + Unpin> {
+pub struct TimeoutFuture<F: Future + Unpin> {
     future: F,
     delay: Delay,
 }
 
-impl<F: Future + Unpin> Future for Timeout<F> {
+impl<F: Future + Unpin> Future for TimeoutFuture<F> {
     type Output = Result<F::Output, io::Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -69,8 +69,8 @@ pub trait FutureExt: Future + Sized + Unpin {
     ///     }
     /// }
     /// ```
-    fn timeout(self, dur: Duration) -> Timeout<Self> {
-        Timeout {
+    fn timeout(self, dur: Duration) -> TimeoutFuture<Self> {
+        TimeoutFuture {
             delay: Delay::new(dur),
             future: self,
         }
@@ -108,8 +108,8 @@ pub trait FutureExt: Future + Sized + Unpin {
     ///     }
     /// }
     /// ```
-    fn timeout_at(self, at: Instant) -> Timeout<Self> {
-        Timeout {
+    fn timeout_at(self, at: Instant) -> TimeoutFuture<Self> {
+        TimeoutFuture {
             delay: Delay::new_at(at),
             future: self,
         }


### PR DESCRIPTION
Signed-off-by: Yoshua Wuyts <yoshuawuyts@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
- rename `Timeout` to `TimeoutFuture`
- added more links / docs to the futures

## Motivation and Context
I was noticing the `time` submodule feels rather noisy. This should help clarify things slightly. We probably should look to add free functions to create new delays at some point too to help cut through some more of the noise. But that can happen in a separate PR. Thanks!

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

Technically a breaking change because we renamed a future type, but I don't expect this to break anyone's build.
