### PR TITLE
Require runtime argument if no default runtime is set

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ edition = "2018"
 
 [features]
 default = ["native"]
-native = ["runtime-native"]
+native = ["runtime-attributes/native", "runtime-native"]
 
 [dependencies]
 futures-preview = "0.3.0-alpha.16"
-runtime-attributes = { path = "runtime-attributes", version = "0.3.0-alpha.5" }
+runtime-attributes = { path = "runtime-attributes", version = "0.3.0-alpha.5", default-features = false }
 runtime-raw = { path = "runtime-raw", version = "0.3.0-alpha.4" }
 runtime-native = { path = "runtime-native", version = "0.3.0-alpha.4", optional = true }
 

--- a/runtime-attributes/Cargo.toml
+++ b/runtime-attributes/Cargo.toml
@@ -15,6 +15,10 @@ edition = "2018"
 [lib]
 proc-macro = true
 
+[features]
+default = ["native"]
+native = []
+
 [dependencies]
 syn = { version = "0.15.33", features = ["full"] }
 proc-macro2 = { version = "0.4.29", features = ["nightly"] }

--- a/runtime-attributes/src/lib.rs
+++ b/runtime-attributes/src/lib.rs
@@ -28,7 +28,14 @@ use syn::spanned::Spanned;
 #[proc_macro_attribute]
 pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
     let rt = if attr.is_empty() {
-        syn::parse_str("runtime::native::Native").unwrap()
+        if cfg!(feature = "native") {
+            syn::parse_str("runtime::native::Native").unwrap()
+        } else {
+            let tokens = quote_spanned! { proc_macro2::Span::call_site() =>
+                compile_error!("async runtime needs to be specified if no default runtime is set");
+            };
+            return TokenStream::from(tokens);
+        }
     } else {
         syn::parse_macro_input!(attr as syn::Expr)
     };
@@ -86,7 +93,14 @@ pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn test(attr: TokenStream, item: TokenStream) -> TokenStream {
     let rt = if attr.is_empty() {
-        syn::parse_str("runtime::native::Native").unwrap()
+        if cfg!(feature = "native") {
+            syn::parse_str("runtime::native::Native").unwrap()
+        } else {
+            let tokens = quote_spanned! { proc_macro2::Span::call_site() =>
+                compile_error!("async runtime needs to be specified if no default runtime is set");
+            };
+            return TokenStream::from(tokens);
+        }
     } else {
         syn::parse_macro_input!(attr as syn::Expr)
     };
@@ -132,7 +146,14 @@ pub fn test(attr: TokenStream, item: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn bench(attr: TokenStream, item: TokenStream) -> TokenStream {
     let rt = if attr.is_empty() {
-        syn::parse_str("runtime::native::Native").unwrap()
+        if cfg!(feature = "native") {
+            syn::parse_str("runtime::native::Native").unwrap()
+        } else {
+            let tokens = quote_spanned! { proc_macro2::Span::call_site() =>
+                compile_error!("async runtime needs to be specified if no default runtime is set");
+            };
+            return TokenStream::from(tokens);
+        }
     } else {
         syn::parse_macro_input!(attr as syn::Expr)
     };


### PR DESCRIPTION
## Description
- `native` (default) feature is added to `runtime-attributes`.
- When `runtime-attributes` is compiled with `default-features = false`, proc-macros will show appropriate error message if runtime argument is not given.

## Motivation and Context
Tries to resolve #57. I have no idea how this PR interacts with #27 though; @yoshuawuyts could you elaborate on this?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
  - Maybe not, I'm not sure.
