### PR TITLE
Remove usage of async_closure

### DIFF
--- a/examples/guessing.rs
+++ b/examples/guessing.rs
@@ -63,9 +63,11 @@ async fn main() -> Result<(), failure::Error> {
 
     let incoming = listener.incoming().map_err(|e| e.into());
     incoming
-        .try_for_each_concurrent(None, async move |stream| {
-            runtime::spawn(play(stream)).await?;
-            Ok::<(), failure::Error>(())
+        .try_for_each_concurrent(None, |stream| {
+            async move {
+                runtime::spawn(play(stream)).await?;
+                Ok::<(), failure::Error>(())
+            }
         })
         .await?;
     Ok(())

--- a/examples/tcp-echo.rs
+++ b/examples/tcp-echo.rs
@@ -16,15 +16,17 @@ async fn main() -> std::io::Result<()> {
     // accept connections and process them in parallel
     listener
         .incoming()
-        .try_for_each_concurrent(None, async move |stream| {
-            runtime::spawn(async move {
-                println!("Accepting from: {}", stream.peer_addr()?);
+        .try_for_each_concurrent(None, |stream| {
+            async move {
+                runtime::spawn(async move {
+                    println!("Accepting from: {}", stream.peer_addr()?);
 
-                let (reader, writer) = &mut stream.split();
-                reader.copy_into(writer).await?;
-                Ok::<(), std::io::Error>(())
-            })
-            .await
+                    let (reader, writer) = &mut stream.split();
+                    reader.copy_into(writer).await?;
+                    Ok::<(), std::io::Error>(())
+                })
+                .await
+            }
         })
         .await?;
     Ok(())

--- a/examples/tcp-proxy.rs
+++ b/examples/tcp-proxy.rs
@@ -14,24 +14,26 @@ async fn main() -> std::io::Result<()> {
     // accept connections and process them in parallel
     listener
         .incoming()
-        .try_for_each_concurrent(None, async move |client| {
-            runtime::spawn(async move {
-                let server = TcpStream::connect("127.0.0.1:8080").await?;
-                println!(
-                    "Proxying {} to {}",
-                    client.peer_addr()?,
-                    server.peer_addr()?
-                );
+        .try_for_each_concurrent(None, |client| {
+            async move {
+                runtime::spawn(async move {
+                    let server = TcpStream::connect("127.0.0.1:8080").await?;
+                    println!(
+                        "Proxying {} to {}",
+                        client.peer_addr()?,
+                        server.peer_addr()?
+                    );
 
-                let (cr, cw) = &mut client.split();
-                let (sr, sw) = &mut server.split();
-                let a = cr.copy_into(sw);
-                let b = sr.copy_into(cw);
-                try_join!(a, b)?;
+                    let (cr, cw) = &mut client.split();
+                    let (sr, sw) = &mut server.split();
+                    let a = cr.copy_into(sw);
+                    let b = sr.copy_into(cw);
+                    try_join!(a, b)?;
 
-                Ok::<(), std::io::Error>(())
-            })
-            .await
+                    Ok::<(), std::io::Error>(())
+                })
+                .await
+            }
         })
         .await?;
     Ok(())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Since `async_closure` was separated from `async_await`, 3 examples are broken in the latest nightly.

Related: https://github.com/rust-lang-nursery/futures-rs/pull/1716#issuecomment-508964777

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
