### PR TITLE
Remove unnecessary `Unpin` requirements in `time::*`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Getting things right takes time. But if you'd like to move the state of async fo
 you to get involved!
 
 ## Safety
-This crate uses ``#![deny(unsafe_code)]`` to ensure everything is implemented in 100% Safe Rust.
+This crate uses `unsafe` in a few places to construct pin projections.
 
 ## Contributing
 Want to join us? Check out our [The "Contributing" section of the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,6 @@
 //!   a work-stealing scheduler.
 
 #![feature(async_await)]
-#![deny(unsafe_code)]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/src/time/ext.rs
+++ b/src/time/ext.rs
@@ -155,7 +155,11 @@ impl<S: Stream> Stream for TimeoutStream<S> {
         // This pinning projection is safe.
         // See detail in `Timeout::poll`.
         let (mut timeout, dur, stream) = unsafe {
-            let TimeoutStream { timeout, dur, stream } = self.get_unchecked_mut();
+            let TimeoutStream {
+                timeout,
+                dur,
+                stream,
+            } = self.get_unchecked_mut();
             (Pin::new(timeout), Pin::new(dur), Pin::new_unchecked(stream))
         };
 
@@ -238,7 +242,11 @@ impl<S: AsyncRead> AsyncRead for TimeoutAsyncRead<S> {
         // This pinning projection is safe.
         // See detail in `Timeout::poll`.
         let (mut timeout, dur, stream) = unsafe {
-            let TimeoutAsyncRead { timeout, dur, stream } = self.get_unchecked_mut();
+            let TimeoutAsyncRead {
+                timeout,
+                dur,
+                stream,
+            } = self.get_unchecked_mut();
             (Pin::new(timeout), Pin::new(dur), Pin::new_unchecked(stream))
         };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Remove unnecessary `Unpin` requirements in `time::*`. (fixes #65)

**DANGER**: It contains `unsafe` code breaking `#![deny(unsafe_code)]`, which seems not able to avoid now. But I have already checked [Projections and Structural Pinning](https://doc.rust-lang.org/stable/std/pin/index.html#projections-and-structural-pinning) and think the code is actually safe. But it still need more revisions.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It will allow us to set timeout on `async fn` or `async` blocks, which may not be `Unpin`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
