### PR TITLE
Proper runtime "enter" instead of spawn + local blocking

### DIFF
--- a/runtime-native/Cargo.toml
+++ b/runtime-native/Cargo.toml
@@ -19,7 +19,6 @@ runtime-raw = { path = "../runtime-raw", version = "0.3.0-alpha.4" }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 async-datagram = "3.0.0"
 juliex = "0.3.0-alpha.6"
-lazy_static = "1.3.0"
 romio = "0.3.0-alpha.9"
 futures-timer = "0.3.0"
 

--- a/runtime-tokio/Cargo.toml
+++ b/runtime-tokio/Cargo.toml
@@ -15,7 +15,6 @@ edition = "2018"
 [dependencies]
 futures-preview = { version = "0.3.0-alpha.16", features = ["compat", "io-compat"] }
 futures01 = { package = "futures", version = "0.1" }
-lazy_static = "1.3.0"
 mio = "0.6.16"
 runtime-raw = { path = "../runtime-raw", version = "0.3.0-alpha.4" }
 tokio = "0.1.19"

--- a/runtime-tokio/src/lib.rs
+++ b/runtime-tokio/src/lib.rs
@@ -12,17 +12,14 @@
 
 use futures::{
     compat::Future01CompatExt,
-    future::{BoxFuture, FutureExt, TryFutureExt},
+    future::{BoxFuture, Future, FutureExt, TryFutureExt},
     task::SpawnError,
 };
-use lazy_static::lazy_static;
 use tokio::timer::{Delay as TokioDelay, Interval as TokioInterval};
 
 use std::io;
 use std::net::SocketAddr;
 use std::pin::Pin;
-use std::sync::{mpsc, Mutex};
-use std::thread;
 use std::time::{Duration, Instant};
 
 mod tcp;
@@ -33,25 +30,21 @@ use tcp::{TcpListener, TcpStream};
 use time::{Delay, Interval};
 use udp::UdpSocket;
 
-/// The default Tokio runtime.
-#[derive(Debug)]
-pub struct Tokio;
+// No matter how we "enter" the `BlockingRuntime` the `Runtime` interface to
+// tokio is the same
+struct TokioRuntime;
 
-impl runtime_raw::Runtime for Tokio {
+impl runtime_raw::Runtime for TokioRuntime {
     fn spawn_boxed(&self, fut: BoxFuture<'static, ()>) -> Result<(), SpawnError> {
-        lazy_static! {
-            static ref TOKIO_RUNTIME: tokio::runtime::Runtime = {
-                tokio::runtime::Builder::new()
-                    .after_start(|| {
-                        runtime_raw::set_runtime(&Tokio);
-                    })
-                    .build()
-                    .unwrap()
-            };
-        }
-
-        TOKIO_RUNTIME.executor().spawn(fut.unit_error().compat());
-        Ok(())
+        use tokio::executor::Executor;
+        let mut e = tokio::executor::DefaultExecutor::current();
+        e.spawn(Box::new(fut.unit_error().compat())).map_err(|e| {
+            if e.is_shutdown() {
+                SpawnError::shutdown()
+            } else {
+                panic!("can't handle tokio spawn error: {}", e);
+            }
+        })
     }
 
     fn connect_tcp_stream(
@@ -99,82 +92,44 @@ impl runtime_raw::Runtime for Tokio {
     }
 }
 
+/// The default Tokio runtime.
+///
+/// Uses a dedicated tokio instace to drive the runtime and cleans up afterwards.
+#[derive(Debug)]
+pub struct Tokio;
+
+impl<F, T> runtime_raw::BlockingRuntime<F, T> for Tokio
+where
+    F: Future<Output = T> + Send + 'static,
+    T: Send + 'static,
+{
+    fn block_on(&self, fut: F) -> T {
+        let mut rt = tokio::runtime::Builder::new()
+            .after_start(move || {
+                runtime_raw::set_runtime(&TokioRuntime);
+            })
+            .build()
+            .unwrap();
+
+        runtime_raw::enter_runtime(&TokioRuntime, || {
+            rt.block_on(fut.unit_error().boxed().compat()).unwrap()
+        })
+    }
+}
+
 /// The single-threaded Tokio runtime based on `tokio-current-thread`.
 #[derive(Debug)]
 pub struct TokioCurrentThread;
 
-impl runtime_raw::Runtime for TokioCurrentThread {
-    fn spawn_boxed(&self, fut: BoxFuture<'static, ()>) -> Result<(), SpawnError> {
-        lazy_static! {
-            static ref TOKIO_RUNTIME: Mutex<tokio::runtime::current_thread::Handle> = {
-                let (tx, rx) = mpsc::channel();
+impl<F, T> runtime_raw::BlockingRuntime<F, T> for TokioCurrentThread
+where
+    F: Future<Output = T>,
+{
+    fn block_on(&self, fut: F) -> T {
+        runtime_raw::enter_runtime(&TokioRuntime, move || {
+            let mut rt = tokio::runtime::current_thread::Runtime::new().unwrap();
 
-                thread::spawn(move || {
-                    let mut rt = tokio::runtime::current_thread::Runtime::new().unwrap();
-                    let handle = rt.handle();
-                    tx.send(handle).unwrap();
-
-                    runtime_raw::set_runtime(&TokioCurrentThread);
-                    let forever = futures01::future::poll_fn(|| {
-                        Ok::<futures01::Async<()>, ()>(futures01::Async::NotReady)
-                    });
-                    rt.block_on(forever).unwrap();
-                });
-
-                let handle = rx.recv().unwrap();
-                Mutex::new(handle)
-            };
-        }
-
-        TOKIO_RUNTIME
-            .lock()
-            .unwrap()
-            .spawn(fut.unit_error().compat())
-            .unwrap();
-        Ok(())
-    }
-
-    fn connect_tcp_stream(
-        &self,
-        addr: &SocketAddr,
-    ) -> BoxFuture<'static, io::Result<Pin<Box<dyn runtime_raw::TcpStream>>>> {
-        use futures01::Future;
-
-        let tokio_connect = tokio::net::TcpStream::connect(addr);
-        let connect = tokio_connect.map(|tokio_stream| {
-            Box::pin(TcpStream { tokio_stream }) as Pin<Box<dyn runtime_raw::TcpStream>>
-        });
-        connect.compat().boxed()
-    }
-
-    fn bind_tcp_listener(
-        &self,
-        addr: &SocketAddr,
-    ) -> io::Result<Pin<Box<dyn runtime_raw::TcpListener>>> {
-        let tokio_listener = tokio::net::TcpListener::bind(&addr)?;
-        Ok(Box::pin(TcpListener { tokio_listener }))
-    }
-
-    fn bind_udp_socket(
-        &self,
-        addr: &SocketAddr,
-    ) -> io::Result<Pin<Box<dyn runtime_raw::UdpSocket>>> {
-        let tokio_socket = tokio::net::UdpSocket::bind(&addr)?;
-        Ok(Box::pin(UdpSocket { tokio_socket }))
-    }
-
-    fn new_delay(&self, dur: Duration) -> Pin<Box<dyn runtime_raw::Delay>> {
-        let tokio_delay = TokioDelay::new(Instant::now() + dur);
-        Box::pin(Delay { tokio_delay })
-    }
-
-    fn new_delay_at(&self, at: Instant) -> Pin<Box<dyn runtime_raw::Delay>> {
-        let tokio_delay = TokioDelay::new(at);
-        Box::pin(Delay { tokio_delay })
-    }
-
-    fn new_interval(&self, dur: Duration) -> Pin<Box<dyn runtime_raw::Interval>> {
-        let tokio_interval = TokioInterval::new(Instant::now(), dur);
-        Box::pin(Interval { tokio_interval })
+            rt.block_on(fut.unit_error().boxed_local().compat()).unwrap()
+        })
     }
 }


### PR DESCRIPTION
Remove the necessity to spawn threads by using an explicit `enter` method in the `Runtime` trait which blocks on the passed future.

## Description, Motivation and Context

Currently all runtimes need to run in background threads / worker pools.

With this PR this is changed: there is an explicit `enter` which is supposed to block on the passed future, so a `current_thread` runtime doesn't need to spawn new threads (which makes strace way easier to read, and is simply cleaner imho).

This also removes various (lazy_statics) globals: if a runtime is `enter`ed again, it will simply have to recreate the runtime environment, and it should shutdown cleanly on leaving `enter`. (One might argue whether it should only block on the passed future or on a more generic "runtime shutdown".)

The second commit avoids double-boxing with a more generic `JoinHandle` and its type-erased `CompletionHandle` part.

This also makes it more explicit that `enter` can't work on wasm; I went for a simple panic though instead of going `#[cfg(...)]`-crazy over the API (especially as the existing wasm cfg handling is broken and looks wrong).

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

(Although the breaking change should only be visible for `runtime_raw` users.)