### PR TITLE
fix false must_use warning on JoinHandle

### DIFF
--- a/src/task.rs
+++ b/src/task.rs
@@ -85,7 +85,6 @@ where
 /// A handle that awaits the result of a [`spawn`]ed future.
 ///
 /// [`spawn`]: fn.spawn.html
-#[must_use = "futures do nothing unless you `.await` or poll them"]
 #[derive(Debug)]
 pub struct JoinHandle<T> {
     pub(crate) rx: futures::channel::oneshot::Receiver<T>,


### PR DESCRIPTION
Removes the `must_use` requirement on the `JoinHandle`

## Motivation and Context
The `must_use` requirement is a bit misleading, since the `JoinHandle` is the
result of a future being spawned, and thus the originating future will be
polled to completion, whether or not the `JoinHandle` is polled.

This seems like it may overlap with some of the changes in #73, where it may be desirable to instead use a `RemoteHandle` - but since there is some open discussion, this seems like a worthy (and simple) change.

Another option might be to add a `.forget()` method which consumes the `JoinHandle` directly, and is thus a bit more explicit.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
