### PR TITLE
Replace `JoinHandle` with `RemoteHandle`

### DIFF
--- a/benches/baseline.rs
+++ b/benches/baseline.rs
@@ -101,7 +101,7 @@ mod baseline {
                                     }
                                 }))
                                 .map(|_: Result<(), ()>| ()),
-                            )
+                            ).await
                         })
                     })
                     .collect::<Vec<_>>();

--- a/benches/common/mod.rs
+++ b/benches/common/mod.rs
@@ -83,7 +83,7 @@ macro_rules! benchmark_suite {
                                 }
                             }))
                             .map(|_: Result<(), ()>| ()),
-                        )
+                        ).await
                     })
                 })
                 .collect::<Vec<_>>();


### PR DESCRIPTION
Replace `JoinHandle` with [`RemoteHandle` from `futures`](https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.17/futures/future/struct.RemoteHandle.html).

This is a counter proposal to #78.

It changes the semantic a little (`RemoteHandle` must actually be used; if dropped without calling `forget` it will cancel the future) - basically the opposite direction of #78.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
