### PR TITLE
Update syn, proc-macro2, quote to 1.0

### DIFF
--- a/runtime-attributes/Cargo.toml
+++ b/runtime-attributes/Cargo.toml
@@ -20,9 +20,9 @@ default = ["native"]
 native = []
 
 [dependencies]
-syn = { version = "0.15.33", features = ["full"] }
-proc-macro2 = { version = "0.4.29", features = ["nightly"] }
-quote = "0.6.12"
+syn = { version = "1.0.1", features = ["full"] }
+proc-macro2 = { version = "1.0.0", features = ["nightly"] }
+quote = "1.0.0"
 
 [dev-dependencies]
 runtime-raw = { path = "../runtime-raw", version = "0.3.0-alpha.4" }

--- a/runtime-attributes/src/lib.rs
+++ b/runtime-attributes/src/lib.rs
@@ -41,9 +41,9 @@ pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
     };
     let input = syn::parse_macro_input!(item as syn::ItemFn);
 
-    let ret = &input.decl.output;
-    let inputs = &input.decl.inputs;
-    let name = &input.ident;
+    let ret = &input.sig.output;
+    let args = input.sig.inputs.iter();
+    let name = &input.sig.ident;
     let body = &input.block;
     let attrs = &input.attrs;
 
@@ -54,7 +54,7 @@ pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
         return TokenStream::from(tokens);
     }
 
-    if input.asyncness.is_none() {
+    if input.sig.asyncness.is_none() {
         let tokens = quote_spanned! { input.span() =>
           compile_error!("the async keyword is missing from the function declaration");
         };
@@ -64,7 +64,7 @@ pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
     let result = quote! {
         fn main() #ret {
             #(#attrs)*
-            async fn main(#(#inputs),*) #ret {
+            async fn main(#(#args),*) #ret {
                 #body
             }
 
@@ -72,7 +72,6 @@ pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
                 main().await
             })
         }
-
     };
 
     result.into()
@@ -106,12 +105,12 @@ pub fn test(attr: TokenStream, item: TokenStream) -> TokenStream {
     };
     let input = syn::parse_macro_input!(item as syn::ItemFn);
 
-    let ret = &input.decl.output;
-    let name = &input.ident;
+    let ret = &input.sig.output;
+    let name = &input.sig.ident;
     let body = &input.block;
     let attrs = &input.attrs;
 
-    if input.asyncness.is_none() {
+    if input.sig.asyncness.is_none() {
         let tokens = quote_spanned! { input.span() =>
           compile_error!("the async keyword is missing from the function declaration");
         };
@@ -159,12 +158,12 @@ pub fn bench(attr: TokenStream, item: TokenStream) -> TokenStream {
     };
     let input = syn::parse_macro_input!(item as syn::ItemFn);
 
-    let args = &input.decl.inputs;
-    let name = &input.ident;
+    let args = &input.sig.inputs;
+    let name = &input.sig.ident;
     let body = &input.block;
     let attrs = &input.attrs;
 
-    if input.asyncness.is_none() {
+    if input.sig.asyncness.is_none() {
         let tokens = quote_spanned! { input.span() =>
           compile_error!("the async keyword is missing from the function declaration");
         };


### PR DESCRIPTION
## Description
Closes #93, closes #94, closes #95. 

`syn` and `quote` had some non-trivial breaking changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
  - I'm not sure about this. Semver-breaking dependency upgrade is technically a breaking change, but in this case those packages are for internal use only.
